### PR TITLE
Update 2023-09-03-av1-for-dummies.md

### DIFF
--- a/blog/2023-09-03-av1-for-dummies.md
+++ b/blog/2023-09-03-av1-for-dummies.md
@@ -275,7 +275,7 @@ When there's no errors, proceed to compiling `aom-av1-lavish`.
 
 Install dependencies:
 ```bash
-sudo pacman -S vapoursynth ffmpeg av1an mkvtoolnix-gui git perl cmake ninja meson nasm vapoursynth-plugin-lsmashsource ffms2
+sudo pacman -S vapoursynth ffmpeg av1an mkvtoolnix-gui git perl cmake ninja meson nasm vapoursynth-plugin-lsmashsource ffms2 base-devel
 ```
 
 you're done, proceed.


### PR DESCRIPTION
added "base-devel" to "install dependencies" in section "Arch"