### PR TITLE
[Feat]: Add Image Carousels with Ant Design

### DIFF
--- a/blog/2023-12-30-svt-av1-deep-dive.mdx
+++ b/blog/2023-12-30-svt-av1-deep-dive.mdx
@@ -1,5 +1,3 @@
-import { CarouselGenerator } from '../src/utils/ImageCarousel.mdx';
-
 ---
 title: "Encoding Animation with SVT-AV1: A Deep Dive"
 description: "With the recent release of SVT-AV1 1.8.0, how does it stack up for encoding animation?"
@@ -13,6 +11,8 @@ tags: [video, compression, benchmarks]
 image: /img/svt-1.8.0-testing-blog-image.webp
 hide_table_of_contents: false
 ---
+
+import { CarouselGenerator } from '../src/utils/ImageCarousel.mdx';
 
 # Introduction
 

--- a/blog/2023-12-30-svt-av1-deep-dive.mdx
+++ b/blog/2023-12-30-svt-av1-deep-dive.mdx
@@ -1,3 +1,5 @@
+import { CarouselGenerator } from '../src/utils/ImageCarousel.mdx';
+
 ---
 title: "Encoding Animation with SVT-AV1: A Deep Dive"
 description: "With the recent release of SVT-AV1 1.8.0, how does it stack up for encoding animation?"
@@ -57,65 +59,148 @@ And more, like CDEF and restoration enabled, overlays and film-grain disabled...
 
 - First of all, here are the efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={[
+    {
+      src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_blame.webp',
+      alt: 'Blame!.h264 Efficiency Graph',
+    },
+    {
+      src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_bluelock.webp',
+      alt: 'BlueLock.h264 Efficiency Graph',
+    },
+    {
+      src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_fate.webp',
+      alt: 'Fate.h264 Efficiency Graph',
+    },
+    {
+      src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_jigokuraku.webp',
+      alt: 'Jigokuraku.h264 Efficiency Graph',
+    },
+    {
+      src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-graphs/SVT4_kaguya.webp',
+      alt: 'Kaguya.h264 Efficiency Graph',
+    },
+  ]}
+/>
 
 This could be too much information.
 
 - Now the same graphs but focusing on the "high quality" range (CRF8 -> 23):
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_blame.webp',
+        alt: 'blame High Quality Efficiency Graph',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_bluelock.webp',
+        alt: 'bluelock High Quality Efficiency Graph',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_fate.webp',
+        alt: 'fate High Quality Efficiency Graph',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_jigokuraku.webp',
+        alt: 'jigokuraku High Quality Efficiency Graph',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq/SVT4_kaguya.webp',
+        alt: 'kaguya High Quality Efficiency Graph',
+      },
+    ]
+  }
+/>
 
 - Same again but without presets 9 to 13 for better clarity:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-highq-slow/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Now for the "low quality" range (CRF28 -> 43):
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Same but without presets 9 to 13 for better clarity:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/svt-efficiency-lowq-slow/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - **Let's now see speed comparisons between all presets:**
 
@@ -126,39 +211,90 @@ As we can see, preset -1 is so abysmally slow it makes the graph unusable
 
 - Here is what it looks like with a logarithmic scale:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-bpp/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - **Now the speed graphs but with SSIMU2 on the y-axis instead of BPP: (logarithmic scale)**
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-log-ssimu2/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Here are speeds graphs for preset 1 to 6 with a linear scale:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/speed-linear-bpp/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 One interpretation we can have is that **presets 2 to 4** have actually pretty close scores (pretty much the same at HQ, 2 points at max in the low quality range) but **preset 2** is **2x slower than preset 4**. The quality gap between **preset 2** and **preset 1** is even narrower but the speed penalty is also ~2x.
 
@@ -182,51 +318,119 @@ Except for the tunes, `--preset 4` is set due to its good balance of quality and
 
 - **Let's compare the efficiency of every tunes:**
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Now let's focus on the "high quality" range (CRF8 -> 23):
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-highq/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - And the "low quality" range (CRF28 -> 43):
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-efficiency-lowq/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - And here is the speed difference:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tunes-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Graphs comparing the tunes individually between each others will be made available soon.
 - The image comparisons will make the conclusion quite more nuanced, stay tuned (heheh) for that.
@@ -249,27 +453,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tile-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > __tiles__ here are both slightly harmful and slower.
 
@@ -277,27 +515,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > Except for the Jigokuraku clip, __aq-mode 0__ is harmful in the eyes of SSIMU2, while being slower at low CRF levels, and sometimes a match or faster at high CRF levels.
 
@@ -305,27 +577,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/aq-mode1-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > __aq-mode 1__ fares closer to __aq-mode 2__ than __aq-mode 0__ did, both in quality and speed, but is still overall inferior according to SSIMU2
 
@@ -333,27 +639,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/cdef-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > According to SSIMU2, disabling CDEF barely impact efficiency. But as its a pretty demanding tool, there's a slight speed benefit of having it disabled too. I advise you to take these results with a grain of salt until the image comparisons, because in anime particularly, CDEF *can* be beneficial for the line-art.
 
@@ -361,27 +701,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dg-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > __Dynamic GoP control__ yields bit-perfect results in all clips except for Blue Lock and Jigokuraku. There is no speed benefit to disabling it except in clips where it is in use. Let's not jump to conclusions too easily, the image comparisons will tell if it's "safe" to keep the setting disabled at all times or not.
 
@@ -389,27 +763,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/dlf-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > __Deblocking loop filter__ can be slightly beneficial in some scenarios. In reverse, it is never harmful, so it is recommended to keep it default.
 
@@ -417,27 +825,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/fast-decode-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > __fast-decode 1__ is pretty harmful in the Fate clip and slightly harmful in the rest. There is a speed benefit of enabling it though.
 
@@ -445,27 +887,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/irefresh-type1-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > Finally something interesting to analyse!
 - __irefresh-type 1__ is either a match or beneficial compared to __irefresh-type 2__ at high CRF levels.
@@ -477,79 +953,180 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_kaguya.webp)
-
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 ### `--lookahead 60` vs default `--lookahead -1` (auto)
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead60-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 ### `--lookahead 120` (max) vs default `--lookahead -1` (auto)
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame'
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock'
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate'
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku'
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya'
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/lookahead120-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > __lookahead__ seems to behave strangely when set...
 - __lookahead 0__ shifts quality around a lot and it is difficult to draw conclusions but there's a clear speed drawback of disabling lookahead.
@@ -561,27 +1138,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/overlays-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > __overlays__ do not seem to either improve efficiency or performance.
 
@@ -589,27 +1200,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > Enabling __quantization matrices__ alone increase efficiency at "high quality" with no real speed impact.
 
@@ -617,27 +1262,61 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_blame.webp',
+        alt: 'SVT4_qm1_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_bluelock.webp',
+        alt: 'SVT4_qm1_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_fate.webp',
+        alt: 'SVT4_qm1_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_jigokuraku.webp',
+        alt: 'SVT4_qm1_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-efficiency/SVT4_qm1_kaguya.webp',
+        alt: 'SVT4_qm1_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_blame.webp',
+        alt: 'SVT4_qm1_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_bluelock.webp',
+        alt: 'SVT4_qm1_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_fate.webp',
+        alt: 'SVT4_qm1_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_jigokuraku.webp',
+        alt: 'SVT4_qm1_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/qm-min-speed/SVT4_qm1_kaguya.webp',
+        alt: 'SVT4_qm1_kaguya',
+      },
+    ]
+  }
+/>
 
 > Setting __qm-min__ to __0__ on top of enabling __quantization matrices__ can be beneficial in some clips at no added compute time.
 
@@ -647,27 +1326,61 @@ I will re-tests many QMs ranges in the future, but I doubt it changed much from 
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/restoration-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > Even though the efficiencies are very similar, nothing is bit-perfect here. So according to SSIMU2, the __loop restoration filter__ isn't necessarily useful. However, just like CDEF, it's a pretty demanding tool, so disabling it yields some performance improvements. Let's take these with a grain of salt until the image comparisons.
 
@@ -679,27 +1392,61 @@ In all the clips, the results are bit-perfect and there is no notable performanc
 
 - Efficiency graphs:
 
-![scm1-efficiency-1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_blame.webp)
-
-![scm1-efficiency-2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_bluelock.webp)
-
-![scm1-efficiency-3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_fate.webp)
-
-![scm1-efficiency-4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_jigokuraku.webp)
-
-![scm1-efficiency-5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/scm1-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > Interestingly enough, __screen content tools__ seem to improve efficiency according to SSIMU2, at the cost of a huge performance regression. After the image comparisons are published, I will conduct additional testing on this.
 
@@ -707,27 +1454,61 @@ In all the clips, the results are bit-perfect and there is no notable performanc
 
 - Efficiency graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-efficiency/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 - Speed graphs:
 
-![1](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_blame.webp)
-
-![2](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_bluelock.webp)
-
-![3](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_fate.webp)
-
-![4](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_jigokuraku.webp)
-
-![5](https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_kaguya.webp)
+<CarouselGenerator
+  imageData={
+    [
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_blame.webp',
+        alt: 'SVT4_blame',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_bluelock.webp',
+        alt: 'SVT4_bluelock',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_fate.webp',
+        alt: 'SVT4_fate',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_jigokuraku.webp',
+        alt: 'SVT4_jigokuraku',
+      },
+      {
+        src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-trix-blogpost/tf-speed/SVT4_kaguya.webp',
+        alt: 'SVT4_kaguya',
+      },
+    ]
+  }
+/>
 
 > Disabled __temporal filtering__ *can* sometimes improve efficiency slightly at "high quality", however it is very much clip dependent. It also improves performance slightly. The image comparisons will give another perspective to these results.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "codec-wiki",
       "version": "0.1.0",
       "dependencies": {
+        "@ant-design/icons": "^5.3.6",
         "@docusaurus/core": "^3.1.1",
         "@docusaurus/preset-classic": "^3.1.1",
         "@easyops-cn/docusaurus-search-local": "latest",
         "@mdx-js/react": "^3.0.0",
+        "antd": "^5.16.0",
         "clsx": "^1.2.1",
         "plugin-image-zoom": "latest",
         "prism-react-renderer": "^2.1.0",
@@ -197,6 +199,71 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ant-design/colors": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.2.tgz",
+      "integrity": "sha512-7KJkhTiPiLHSu+LmMJnehfJ6242OCxSlR3xHVBecYxnMW8MS/878NXct1GqYARyL59fyeFdKRxXTfvR9SnDgJg==",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.6.1"
+      }
+    },
+    "node_modules/@ant-design/cssinjs": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.19.1.tgz",
+      "integrity": "sha512-hgQ3wiys3X0sqDKWkqCJ6EYdF79i9JCvtavmIGwuuPUKmoJXV8Ff0sY+yQQSxk2dRmMyam/bYKo/Bwor45hnZw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "classnames": "^2.3.1",
+        "csstype": "^3.1.3",
+        "rc-util": "^5.35.0",
+        "stylis": "^4.0.13"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/icons": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.6.tgz",
+      "integrity": "sha512-JeWsgNjvkTTC73YDPgWOgdScRku/iHN9JU0qk39OSEmJSCiRghQMLlxGTCY5ovbRRoXjxHXnUKgQEgBDnQfKmA==",
+      "dependencies": {
+        "@ant-design/colors": "^7.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@babel/runtime": "^7.11.2",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.31.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/icons-svg": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+      "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA=="
+    },
+    "node_modules/@ant-design/react-slick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
+      "integrity": "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.4",
+        "classnames": "^2.2.5",
+        "json2mq": "^0.2.0",
+        "resize-observer-polyfill": "^1.5.1",
+        "throttle-debounce": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2042,9 +2109,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2117,6 +2184,14 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2847,6 +2922,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -3316,6 +3401,118 @@
       "version": "1.0.0-next.25",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ=="
+    },
+    "node_modules/@rc-component/color-picker": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-1.5.3.tgz",
+      "integrity": "sha512-+tGGH3nLmYXTalVe0L8hSZNs73VTP5ueSHwUlDC77KKRaN7G4DS4wcpG5DTDzdcV/Yas+rzA6UGgIyzd8fS4cw==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.6",
+        "@ctrl/tinycolor": "^3.6.1",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.38.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/context": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
+      "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mini-decimal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
+      "integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@rc-component/mutate-observer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
+      "integrity": "sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tour": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.14.2.tgz",
+      "integrity": "sha512-A75DZ8LVvahBIvxooj3Gvf2sxe+CGOkmzPNX7ek0i0AJHyKZ1HXe5ieIGo3m0FMdZfVOlbCJ952Duq8VKAHk6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "@rc-component/portal": "^1.0.0-9",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/trigger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.0.0.tgz",
+      "integrity": "sha512-niwKADPdY5dhdIblV6uwSayVivwo2uUISfJqri+/ovYQcH/omxDYBJKo755QKeoIIsWptxnRpgr7reEnNEZGFg==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/portal": "^1.1.0",
+        "classnames": "^2.3.2",
+        "rc-motion": "^2.0.0",
+        "rc-resize-observer": "^1.3.1",
+        "rc-util": "^5.38.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -4362,6 +4559,69 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/antd": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.16.0.tgz",
+      "integrity": "sha512-2JcZSxTcX5J2Faro5PB85ETAP64cuU91pBqQ2NVHWelmhLXvN3q70R5Qht+E9k3WVsVO8ZbqBJciYqj8K/RbZw==",
+      "dependencies": {
+        "@ant-design/colors": "^7.0.2",
+        "@ant-design/cssinjs": "^1.18.5",
+        "@ant-design/icons": "^5.3.5",
+        "@ant-design/react-slick": "~1.1.1",
+        "@babel/runtime": "^7.24.1",
+        "@ctrl/tinycolor": "^3.6.1",
+        "@rc-component/color-picker": "~1.5.3",
+        "@rc-component/mutate-observer": "^1.1.0",
+        "@rc-component/tour": "~1.14.2",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.5.1",
+        "copy-to-clipboard": "^3.3.3",
+        "dayjs": "^1.11.10",
+        "qrcode.react": "^3.1.0",
+        "rc-cascader": "~3.24.0",
+        "rc-checkbox": "~3.2.0",
+        "rc-collapse": "~3.7.3",
+        "rc-dialog": "~9.4.0",
+        "rc-drawer": "~7.1.0",
+        "rc-dropdown": "~4.2.0",
+        "rc-field-form": "~1.44.0",
+        "rc-image": "~7.6.0",
+        "rc-input": "~1.4.5",
+        "rc-input-number": "~9.0.0",
+        "rc-mentions": "~2.11.1",
+        "rc-menu": "~9.13.0",
+        "rc-motion": "^2.9.0",
+        "rc-notification": "~5.4.0",
+        "rc-pagination": "~4.0.4",
+        "rc-picker": "~4.3.0",
+        "rc-progress": "~4.0.0",
+        "rc-rate": "~2.12.0",
+        "rc-resize-observer": "^1.4.0",
+        "rc-segmented": "~2.3.0",
+        "rc-select": "~14.13.0",
+        "rc-slider": "~10.5.0",
+        "rc-steps": "~6.0.1",
+        "rc-switch": "~4.1.0",
+        "rc-table": "~7.45.0",
+        "rc-tabs": "~14.1.1",
+        "rc-textarea": "~1.6.3",
+        "rc-tooltip": "~6.2.0",
+        "rc-tree": "~5.8.5",
+        "rc-tree-select": "~5.19.0",
+        "rc-upload": "~4.5.2",
+        "rc-util": "^5.39.1",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "throttle-debounce": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ant-design"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -4389,6 +4649,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/array-tree-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
+      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -4404,6 +4669,11 @@
       "bin": {
         "astring": "bin/astring"
       }
+    },
+    "node_modules/async-validator": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
+      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -4989,6 +5259,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -5210,6 +5485,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5298,6 +5578,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/copy-webpack-plugin": {
@@ -5713,6 +6001,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -8320,6 +8613,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -12094,6 +12395,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -12196,6 +12505,583 @@
       },
       "bin": {
         "rc": "cli.js"
+      }
+    },
+    "node_modules/rc-cascader": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.24.0.tgz",
+      "integrity": "sha512-NwkYsVULA61S085jbOYbq8Z7leyIxVmLwf+71mWLjA3kCfUf/rAKC0WfjQbqBDaLGlU9d4z1EzyPaHBKLYWv6A==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "array-tree-filter": "^2.1.0",
+        "classnames": "^2.3.1",
+        "rc-select": "~14.13.0",
+        "rc-tree": "~5.8.1",
+        "rc-util": "^5.37.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-checkbox": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.2.0.tgz",
+      "integrity": "sha512-8inzw4y9dAhZmv/Ydl59Qdy5tdp9CKg4oPVcRigi+ga/yKPZS5m5SyyQPtYSgbcqHRYOdUhiPSeKfktc76du1A==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.25.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-collapse": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.7.3.tgz",
+      "integrity": "sha512-60FJcdTRn0X5sELF18TANwtVi7FtModq649H11mYF1jh83DniMoM4MqY627sEKRCTm4+WXfGDcB7hY5oW6xhyw==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.3.4",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-dialog": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.4.0.tgz",
+      "integrity": "sha512-AScCexaLACvf8KZRqCPz12BJ8olszXOS4lKlkMyzDQHS1m0zj1KZMYgmMCh39ee0Dcv8kyrj8mTqxuLyhH+QuQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/portal": "^1.0.0-8",
+        "classnames": "^2.2.6",
+        "rc-motion": "^2.3.0",
+        "rc-util": "^5.21.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-drawer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.1.0.tgz",
+      "integrity": "sha512-nBE1rF5iZvpavoyqhSSz2mk/yANltA7g3aF0U45xkx381n3we/RKs9cJfNKp9mSWCedOKWt9FLEwZDaAaOGn2w==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@rc-component/portal": "^1.1.1",
+        "classnames": "^2.2.6",
+        "rc-motion": "^2.6.1",
+        "rc-util": "^5.38.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-dropdown": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.0.tgz",
+      "integrity": "sha512-odM8Ove+gSh0zU27DUj5cG1gNKg7mLWBYzB5E4nNLrLwBmYEgYP43vHKDGOVZcJSVElQBI0+jTQgjnq0NfLjng==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.17.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.11.0",
+        "react-dom": ">=16.11.0"
+      }
+    },
+    "node_modules/rc-field-form": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.44.0.tgz",
+      "integrity": "sha512-el7w87fyDUsca63Y/s8qJcq9kNkf/J5h+iTdqG5WsSHLH0e6Usl7QuYSmSVzJMgtp40mOVZIY/W/QP9zwrp1FA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "async-validator": "^4.1.0",
+        "rc-util": "^5.32.2"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-image": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.6.0.tgz",
+      "integrity": "sha512-tL3Rvd1sS+frZQ01i+tkeUPaOeFz2iG9/scAt/Cfs0hyCRVA/w0Pu1J/JxIX8blalvmHE0bZQRYdOmRAzWu4Hg==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@rc-component/portal": "^1.0.2",
+        "classnames": "^2.2.6",
+        "rc-dialog": "~9.4.0",
+        "rc-motion": "^2.6.2",
+        "rc-util": "^5.34.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-input": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.4.5.tgz",
+      "integrity": "sha512-AjzykhwnwYTRSwwgCu70CGKBIAv6bP2nqnFptnNTprph/TF1BAs0Qxl91mie/BR6n827WIJB6ZjaRf9iiMwAfw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.18.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/rc-input-number": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.0.0.tgz",
+      "integrity": "sha512-RfcDBDdWFFetouWFXBA+WPEC8LzBXyngr9b+yTLVIygfFu7HiLRGn/s/v9wwno94X7KFvnb28FNynMGj9XJlDQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/mini-decimal": "^1.0.1",
+        "classnames": "^2.2.5",
+        "rc-input": "~1.4.0",
+        "rc-util": "^5.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-mentions": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.11.1.tgz",
+      "integrity": "sha512-upb4AK1SRFql7qGnbLEvJqLMugVVIyjmwBJW9L0eLoN9po4JmJZaBzmKA4089fNtsU8k6l/tdZiVafyooeKnLw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.2.6",
+        "rc-input": "~1.4.0",
+        "rc-menu": "~9.13.0",
+        "rc-textarea": "~1.6.1",
+        "rc-util": "^5.34.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.13.0.tgz",
+      "integrity": "sha512-1l8ooCB3HcYJKCltC/s7OxRKRjgymdl9htrCeGZcXNaMct0RxZRK6OPV3lPhVksIvAGMgzPd54ClpZ5J4b8cZA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "2.x",
+        "rc-motion": "^2.4.3",
+        "rc-overflow": "^1.3.1",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-motion": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.0.tgz",
+      "integrity": "sha512-XIU2+xLkdIr1/h6ohPZXyPBMvOmuyFZQ/T0xnawz+Rh+gh4FINcnZmMT5UTIj6hgI0VLDjTaPeRd+smJeSPqiQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.21.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-notification": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.4.0.tgz",
+      "integrity": "sha512-li19y9RoYJciF3WRFvD+DvWS70jdL8Fr+Gfb/OshK+iY6iTkwzoigmSIp76/kWh5tF5i/i9im12X3nsF85GYdA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.9.0",
+        "rc-util": "^5.20.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-overflow": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.3.2.tgz",
+      "integrity": "sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.37.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-pagination": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.0.4.tgz",
+      "integrity": "sha512-GGrLT4NgG6wgJpT/hHIpL9nELv27A1XbSZzECIuQBQTVSf4xGKxWr6I/jhpRPauYEWEbWVw22ObG6tJQqwJqWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.38.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-picker": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.3.0.tgz",
+      "integrity": "sha512-bQNB/+NdW55jlQ5lPnNqF5J90Tq4SihLbAF7tzPBvGDJyoYmDgwLm4FN0ZB3Ot9i1v6vJY/1mgqZZTT9jbYc5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.2.1",
+        "rc-overflow": "^1.3.2",
+        "rc-resize-observer": "^1.4.0",
+        "rc-util": "^5.38.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rc-progress": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-4.0.0.tgz",
+      "integrity": "sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.16.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-rate": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.12.0.tgz",
+      "integrity": "sha512-g092v5iZCdVzbjdn28FzvWebK2IutoVoiTeqoLTj9WM7SjA/gOJIw5/JFZMRyJYYVe1jLAU2UhAfstIpCNRozg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.5",
+        "rc-util": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-resize-observer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.0.tgz",
+      "integrity": "sha512-PnMVyRid9JLxFavTjeDXEXo65HCRqbmLBw9xX9gfC4BZiSzbLXKzW3jPz+J0P71pLbD5tBMTT+mkstV5gD0c9Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.38.0",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-segmented": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.3.0.tgz",
+      "integrity": "sha512-I3FtM5Smua/ESXutFfb8gJ8ZPcvFR+qUgeeGFQHBOvRiRKyAk4aBE5nfqrxXx+h8/vn60DQjOt6i4RNtrbOobg==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-motion": "^2.4.4",
+        "rc-util": "^5.17.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/rc-select": {
+      "version": "14.13.0",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.13.0.tgz",
+      "integrity": "sha512-ew34FsaqHokK4dxVrcIxSYrgWJ2XJYlkk32eiOIiEo3GkHUExdCzmozMYaUc2P67c5QJRUvvY0uqCs3QG67h5A==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "2.x",
+        "rc-motion": "^2.0.1",
+        "rc-overflow": "^1.3.1",
+        "rc-util": "^5.16.1",
+        "rc-virtual-list": "^3.5.2"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/rc-slider": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.5.0.tgz",
+      "integrity": "sha512-xiYght50cvoODZYI43v3Ylsqiw14+D7ELsgzR40boDZaya1HFa1Etnv9MDkQE8X/UrXAffwv2AcNAhslgYuDTw==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.5",
+        "rc-util": "^5.27.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-steps": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.1.tgz",
+      "integrity": "sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.7",
+        "classnames": "^2.2.3",
+        "rc-util": "^5.16.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-switch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.1.0.tgz",
+      "integrity": "sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.30.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-table": {
+      "version": "7.45.4",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.45.4.tgz",
+      "integrity": "sha512-6aSbGrnkN2GLSt3s1x+wa4f3j/VEgg1uKPpaLY5qHH1/nFyreS2V7DFJ0TfUb18allf2FQl7oVYEjTixlBXEyQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/context": "^1.4.0",
+        "classnames": "^2.2.5",
+        "rc-resize-observer": "^1.1.0",
+        "rc-util": "^5.37.0",
+        "rc-virtual-list": "^3.11.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-tabs": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-14.1.1.tgz",
+      "integrity": "sha512-5nOr9PVpJy2SWHTLgv1+kESDOb0tFzl0cYU9r9d8LfL0Wg9i/n1B558rmkxdQHgBwMqxmwoyPSAbQROxMQe8nw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "classnames": "2.x",
+        "rc-dropdown": "~4.2.0",
+        "rc-menu": "~9.13.0",
+        "rc-motion": "^2.6.2",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.34.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-textarea": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.6.3.tgz",
+      "integrity": "sha512-8k7+8Y2GJ/cQLiClFMg8kUXOOdvcFQrnGeSchOvI2ZMIVvX5a3zQpLxoODL0HTrvU63fPkRmMuqaEcOF9dQemA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "rc-input": "~1.4.0",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-tooltip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.0.tgz",
+      "integrity": "sha512-iS/3iOAvtDh9GIx1ulY7EFUXUtktFccNLsARo3NPgLf0QW9oT0w3dA9cYWlhqAKmD+uriEwdWz1kH0Qs4zk2Aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-tree": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.8.5.tgz",
+      "integrity": "sha512-PRfcZtVDNkR7oh26RuNe1hpw11c1wfgzwmPFL0lnxGnYefe9lDAO6cg5wJKIAwyXFVt5zHgpjYmaz0CPy1ZtKg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.0.1",
+        "rc-util": "^5.16.1",
+        "rc-virtual-list": "^3.5.1"
+      },
+      "engines": {
+        "node": ">=10.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/rc-tree-select": {
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.19.0.tgz",
+      "integrity": "sha512-f4l5EsmSGF3ggj76YTzKNPY9SnXfFaer7ZccTSGb3urUf54L+cCqyT+UsPr+S5TAr8mZSxJ7g3CgkCe+cVQ6sw==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-select": "~14.13.0",
+        "rc-tree": "~5.8.1",
+        "rc-util": "^5.16.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/rc-upload": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.5.2.tgz",
+      "integrity": "sha512-QO3ne77DwnAPKFn0bA5qJM81QBjQi0e0NHdkvpFyY73Bea2NfITiotqJqVjHgeYPOJu5lLVR32TNGP084aSoXA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "classnames": "^2.2.5",
+        "rc-util": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.39.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.39.1.tgz",
+      "integrity": "sha512-OW/ERynNDgNr4y0oiFmtes3rbEamXw7GHGbkbNd9iRr7kgT03T6fT0b9WpJ3mbxKhyOcAHnGcIoh5u/cjrC2OQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/rc-virtual-list": {
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.11.4.tgz",
+      "integrity": "sha512-NbBi0fvyIu26gP69nQBiWgUMTPX3mr4FcuBQiVqagU0BnuX8WQkiivnMs105JROeuUIFczLrlgUhLQwTWV1XDA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.0",
+        "classnames": "^2.2.6",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.36.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/rc/node_modules/strip-json-comments": {
@@ -12861,6 +13747,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -13037,6 +13928,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "node_modules/search-insights": {
@@ -13572,6 +14471,11 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -13699,6 +14603,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.1.tgz",
+      "integrity": "sha512-EQepAV+wMsIaGVGX1RECzgrcqRRU/0sYOHkeLsZ3fzHaHXZy4DaOOX0vOlGQdlsjkh3mFHAIlVimpwAs4dslyQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -13958,6 +14867,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -13991,6 +14908,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
+    "@ant-design/icons": "^5.3.6",
     "@docusaurus/core": "^3.1.1",
     "@docusaurus/preset-classic": "^3.1.1",
     "@easyops-cn/docusaurus-search-local": "latest",
     "@mdx-js/react": "^3.0.0",
+    "antd": "^5.16.0",
     "clsx": "^1.2.1",
     "plugin-image-zoom": "latest",
     "prism-react-renderer": "^2.1.0",

--- a/src/utils/ImageCarousel.mdx
+++ b/src/utils/ImageCarousel.mdx
@@ -1,0 +1,28 @@
+import { Carousel, Image } from 'antd';
+import { LeftOutlined, RightOutlined } from '@ant-design/icons';
+
+export const CarouselGenerator = ({imageData}) => {
+  // Thanks to Nathan Arritt: https://github.com/ant-design/ant-design/issues/12479#issuecomment-1071492637
+  const Arrow = ({ currentSlide, direction, slideCount, ...carouselProps }) =>
+  direction === 'left' ? (
+    <LeftOutlined {...carouselProps} style={{ color: '#fff', fontSize: 24, width: 24, height: 24, zIndex: 1, left: 10 }} />
+  ) : (
+    <RightOutlined {...carouselProps} style={{ color: '#fff', fontSize: 24, width: 24, height: 24, zIndex: 1, right: 10 }} />
+  );
+
+  return(
+    <Carousel
+      // draggable // Image Preview Button prematurely triggers
+      arrows
+      prevArrow={<Arrow direction="left" />}
+      nextArrow={<Arrow direction="right" />}
+    >
+      {imageData.map(datum => {
+        return <Image
+          key={datum.src}
+          src={datum.src}
+        />;
+      })}
+    </Carousel>
+  );
+};


### PR DESCRIPTION
The _Encoding Animation with SVT-AV1: A Deep Dive_ page has dozens of charts/images that elongate the page, making it cumbersome to scroll to a specific section without using the sidebar. This feature aims to reduce that by grouping the charts into an interactive carousel per grouping of charts.

## Implementation

The feature is implemented using the Ant Design [Carousel](https://ant.design/components/carousel) 
 and [Image](https://ant.design/components/image) React components. Carousel encapsulates a group of images previously all displayed at once into a single interactive component that shows only 1 at a time. The Image component provides additional features such as zooming in and manipulating the image. If the latter is undesired then it can be removed.

As this is the first React component added to the project, it was added as a separate `*.MDX` under `/src/utils/ImageCarousel.mdx`. If more components are to be added in the future, it would be better to refactor that as a single export library instead of individual exports as it is currently.

## Dependencies

Added:
- [Ant Design](https://github.com/ant-design/ant-design)
- [Ant Design Icons](https://github.com/ant-design/ant-design-icons) - Necessary to implement Nathan Arritt's recommendation for adding Left/Right buttons to the Carousel component. You can read more about it [here](https://github.com/ant-design/ant-design/issues/12479#issuecomment-1071492637).

## Caveats and Considerations

- Due to integrating components with markdown, the spacing between text and the components is inconsistent and may need to be adjusted by prepending a div or some Flex/Space component to each chart carousel.
- The first image "dot" indicator is rendered higher for no clear reason.
- The Carousel component supports being dragged, but is incompatible with the underlying Image component as clicking on the Image component also triggers the "zoom" function.
- You cannot switch to a different image _while_ zoomed in. You must exit the zoomed in interface and then switch to the next image on the carousel.

## Preview

Here are 3 screenshots of the feature in action:

![Screenshot 2024-04-04 112452](https://github.com/av1-community-contributors/codec-wiki/assets/142189976/53212afe-c1f6-4960-be62-0dbe106ab897)
![Screenshot 2024-04-04 112512](https://github.com/av1-community-contributors/codec-wiki/assets/142189976/7c0ac286-b403-4079-8019-8620c0e17f25)
![Screenshot 2024-04-04 112536](https://github.com/av1-community-contributors/codec-wiki/assets/142189976/b0acd9f8-b8cd-486f-aacb-03abbf98da04)
