### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/icons": "^5.3.6",
-        "@docusaurus/core": "^3.1.1",
-        "@docusaurus/preset-classic": "^3.1.1",
+        "@docusaurus/core": "^3.2.1",
+        "@docusaurus/preset-classic": "^3.2.1",
         "@easyops-cn/docusaurus-search-local": "latest",
-        "@mdx-js/react": "^3.0.0",
-        "antd": "^5.16.0",
-        "clsx": "^1.2.1",
+        "@mdx-js/react": "^3.0.1",
+        "antd": "^5.16.4",
+        "clsx": "^2.1.1",
         "plugin-image-zoom": "latest",
-        "prism-react-renderer": "^2.1.0",
-        "react": "^18.0.2",
-        "react-dom": "^18.0.2",
-        "yarn": "^1.22.19"
+        "prism-react-renderer": "^2.3.1",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "yarn": "^1.22.22"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.1.1"
+        "@docusaurus/module-type-aliases": "^3.2.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2637,14 +2637,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.2.1.tgz",
@@ -2672,14 +2664,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
@@ -2710,14 +2694,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@docusaurus/theme-translations": {
@@ -2862,6 +2838,14 @@
         "@docusaurus/theme-common": "^2 || ^3",
         "react": "^16.14.0 || ^17 || ^18",
         "react-dom": "^16.14.0 || 17 || ^18"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@easyops-cn/docusaurus-search-local/node_modules/fs-extra": {
@@ -4515,9 +4499,9 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.16.1.tgz",
-      "integrity": "sha512-XAlLRrgYV+nj9FHnkXEPS6HNcKcluEa8v44e7Cixjlp8aOXRhUI6IfZaKpc2MPGjQ+06rp62/dsxOUNJW9kfLA==",
+      "version": "5.16.4",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.16.4.tgz",
+      "integrity": "sha512-H3LtVz5hiNgs0lL8U6pzi11rluR6RDRw1cm2pWX6CsvgZmybWsaTBV2h+d+zmgFfuch53TWs5uztLdAldIoYYw==",
       "dependencies": {
         "@ant-design/colors": "^7.0.2",
         "@ant-design/cssinjs": "^1.18.5",
@@ -4528,12 +4512,12 @@
         "@rc-component/color-picker": "~1.5.3",
         "@rc-component/mutate-observer": "^1.1.0",
         "@rc-component/tour": "~1.14.2",
-        "@rc-component/trigger": "^2.0.0",
+        "@rc-component/trigger": "^2.1.1",
         "classnames": "^2.5.1",
         "copy-to-clipboard": "^3.3.3",
         "dayjs": "^1.11.10",
         "qrcode.react": "^3.1.0",
-        "rc-cascader": "~3.24.0",
+        "rc-cascader": "~3.24.1",
         "rc-checkbox": "~3.2.0",
         "rc-collapse": "~3.7.3",
         "rc-dialog": "~9.4.0",
@@ -4548,13 +4532,13 @@
         "rc-motion": "^2.9.0",
         "rc-notification": "~5.4.0",
         "rc-pagination": "~4.0.4",
-        "rc-picker": "~4.3.0",
+        "rc-picker": "~4.4.1",
         "rc-progress": "~4.0.0",
         "rc-rate": "~2.12.0",
         "rc-resize-observer": "^1.4.0",
         "rc-segmented": "~2.3.0",
-        "rc-select": "~14.13.0",
-        "rc-slider": "~10.5.0",
+        "rc-select": "~14.13.1",
+        "rc-slider": "~10.6.1",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
         "rc-table": "~7.45.4",
@@ -5273,9 +5257,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
@@ -12213,14 +12197,6 @@
         "react": ">=16.0.0"
       }
     },
-    "node_modules/prism-react-renderer/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/prismjs": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
@@ -12675,9 +12651,9 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.3.1.tgz",
-      "integrity": "sha512-1/TGosPALu/CWBEEpBTmZVNTSQXC5qpsI9jSiZdlLSrz6xhgBj39WNGJsmveiWPRgbHlq/vf5nI8cLMCMinZ5w==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.4.2.tgz",
+      "integrity": "sha512-MdbAXvwiGyhb+bHe66qPps8xPQivzEgcyCp3/MPK4T+oER0gOmVRCEDxaD4FhYG/7GLH3rDrHpu79BvEn2JFTQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^2.0.0",
@@ -12795,13 +12771,13 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.5.0.tgz",
-      "integrity": "sha512-xiYght50cvoODZYI43v3Ylsqiw14+D7ELsgzR40boDZaya1HFa1Etnv9MDkQE8X/UrXAffwv2AcNAhslgYuDTw==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.6.2.tgz",
+      "integrity": "sha512-FjkoFjyvUQWcBo1F3RgSglky3ar0+qHLM41PlFVYB4Bj3RD8E/Mv7kqMouLFBU+3aFglMzzctAIWRwajEuueSw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.27.0"
+        "rc-util": "^5.36.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -13007,9 +12983,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0.tgz",
+      "integrity": "sha512-RPutkJftSAldDibyrjuku7q11d3oy6wKOyPe5K1HA/HwwrXcEqBdHsLypkC2FFYjP7bPUa6gbzSBhw4sY2JcDg==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13136,15 +13112,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-zaKdLBftQJnvb7FtDIpZtsAIb2MZU087RM8bRDZU8LVCCFYjPTsDZJNFUWPcVz3HFSN1n/caxi0ca4B/aaVQGQ==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.1"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.3.0"
       }
     },
     "node_modules/react-error-overlay": {
@@ -13819,9 +13795,9 @@
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.1.tgz",
+      "integrity": "sha512-5GKS5JGfiah1O38Vfa9srZE4s3wdHbwjlCrvIookrg2FO9aIwKLOJXuJQFlEfNcVSOXuaL2hzDeY20uVXcUtrw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,20 +15,20 @@
   },
   "dependencies": {
     "@ant-design/icons": "^5.3.6",
-    "@docusaurus/core": "^3.1.1",
-    "@docusaurus/preset-classic": "^3.1.1",
+    "@docusaurus/core": "^3.2.1",
+    "@docusaurus/preset-classic": "^3.2.1",
     "@easyops-cn/docusaurus-search-local": "latest",
-    "@mdx-js/react": "^3.0.0",
-    "antd": "^5.16.0",
-    "clsx": "^1.2.1",
+    "@mdx-js/react": "^3.0.1",
+    "antd": "^5.16.4",
+    "clsx": "^2.1.1",
     "plugin-image-zoom": "latest",
-    "prism-react-renderer": "^2.1.0",
-    "react": "^18.0.2",
-    "react-dom": "^18.0.2",
-    "yarn": "^1.22.19"
+    "prism-react-renderer": "^2.3.1",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "yarn": "^1.22.22"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.1.1"
+    "@docusaurus/module-type-aliases": "^3.2.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Only minor versions are updated(except in case of clsx whose earlier version is deprecated), Decreases package size and speedometer score, shouldn't break anything

```sh
 @docusaurus/core                   ^3.1.1  →    ^3.2.1
 @docusaurus/module-type-aliases    ^3.1.1  →    ^3.2.1
 @docusaurus/preset-classic         ^3.1.1  →    ^3.2.1
 @mdx-js/react                      ^3.0.0  →    ^3.0.1
 antd                              ^5.16.0  →   ^5.16.4
 clsx                               ^1.2.1  →    ^2.1.1
 prism-react-renderer               ^2.1.0  →    ^2.3.1
 react                             ^18.0.2  →   ^18.3.0
 react-dom                         ^18.0.2  →   ^18.3.0
 yarn                             ^1.22.19  →  ^1.22.22
```