### PR TITLE
Add colorimetry information

### DIFF
--- a/docs/colorimetry/_category_.json
+++ b/docs/colorimetry/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "🎨 Colorimetry",
+  "position": 8
+}

--- a/docs/colorimetry/format.mdx
+++ b/docs/colorimetry/format.mdx
@@ -1,0 +1,154 @@
+---
+title: Color Formats
+sidebar_position: 2
+---
+
+# Color Formats
+
+To represent color values, a format is agreed upon. Color formats are
+made up of three things, the [color model](#color-models)--which includes the
+[order of the components](#component-order) and sometimes [chroma subsampling](#chroma-subsampling)--
+the [bit depth](#bit-depth), and whether it is a [packed or a planar format](#packed-vs-planar).
+In some cases, [endianness](#endianness) may be important.
+
+## Color Models
+
+A color model is a method of representing colors in a video or image using data.
+Different color models store color and brightness information in different ways.
+There are many different color models, but this section will cover the
+models most commonly used for images and video.
+
+### RGB
+
+RGB is probably the most well-known color model, and is primarily used
+in image encoding. RGB consists of three color channels, Red, Green,
+and Blue, which are then combined to determine the final color of each
+pixel. Typically, RGB is the final model that a monitor or TV
+will use to display images, because the pixels on a screen are made up
+of red, green, and blue LEDs, although it is not commonly used for video
+encoding because other models can provide better compression.
+
+### YUV
+
+YUV, also known as YCbCr, is the most widely used color model for
+video encoding. It consists of three components: Y aka Luma, which
+represents luminance or brightness, and two chroma planes, which
+represent color. Generally a video player will have to convert a YUV
+video into RGB before it can be rendered, but there are significant
+compression benefits to using YUV over RGB for video.
+
+The most notable reason to use YCbCr is an optimization called chroma
+subsampling. This means that the chroma components can be encoded at a
+lower resolution than the luma components, which results in a smaller
+output file. You can read more about chroma subsampling [further below](#chroma-subsampling).
+
+### Component order
+
+The order in which the components in a color model are arranged is simply
+represented by writing them out. For example, `RGB` for red first,
+then green, then blue, or `BGR` for blue, green, red.
+
+## Bit depth
+
+A bit depth is how many bits are available to store the sample
+value. There are two main ways to specify the bit depth in a :
+
+- bits per component. Here, `RGB888` reads as `RGB color model, with 8
+bits for the red component, 8 bits for the green component, and 8
+bits for the blue component` and `RGB565` reads as `RGB color model,
+with 5 bits for the red component, 6 bits for the green component,
+and 5 bits for the blue component`.
+- bits per sample. Here, `RGB24` reads as `RGB color model, with 24
+bits in total for the red, green, and blue components`. This is
+  ambiguous, because one does not know exactly how many bits are
+  allocated to each component. `RGB565`, `RGB556`, and `RGB655` (even
+  though the latter ones do not make much sense as the eye is most
+  sensitive to green light) all become `RGB16`.
+
+## Packed vs planar
+
+Components can be stored either packed, where all
+components are interleaved (here, `RGB`):
+
+```
+Sample number:   1   2   3   4   5
+Data:          RGB RGB RGB RGB RGB
+```
+
+or stored separately for each component:
+
+```
+Sample number: 1 2 3 4 5
+Data:          R R R R R...
+Data:          G G G G G...
+Data:          B B B B B...
+```
+
+In planar formats, many operations can be easier to implement, as it
+is possible to implement the algorithm once and then operate on all
+planes. On the other hand, packed formats are simpler and often used
+in hardware.[^vlc-wiki-yuv]
+
+## Endianness
+
+Different computer architectures store numbers differently. For more
+information, visit [the Wikipedia article on
+endianness](//wikipedia.org/wiki/Endianness). There are two main ways
+to store numbers with more than 8 bits (1 is the least significant
+byte and 4 is the most significant byte, here 4 bytes):
+
+- Most significant byte first, little endian, `4321`. This is what
+  x86-family processors use.
+- Least significant byte first, big endian, `1234`. This is what
+  PowerPC-family processors use.
+
+This can be important for color formats, as some computers might store
+it in their native endianness. VapourSynth doesn't seem to care about
+endianness, but FFmpeg does.
+
+For example, `RGB565` might store its two bytes in `12` or `21` order,
+and if they are read in the wrong order, it will produce garbage.
+
+## Chroma subsampling
+
+In [Y'CbCr](#yuv) signals, there are three widely used
+variants of chroma subsampling:
+
+- 4:2:0 which has half the vertical and horizontal chroma resolution
+- 4:2:2 which has half the horizontal chroma resolution but full
+  vertical resolution
+- 4:4:4 which has full chroma resolution (no subsampling)
+
+4:2:2 is not particularly useful over the other options, so this guide
+will focus on 4:2:0 and 4:4:4.
+
+4:2:0 is the most commonly used format for videos. Nearly every DVD,
+blu-ray, camera recording, etc. uses 4:2:0 subsampling. This is because,
+in the majority of cases, human eyes do not notice the reduction in
+chroma resolution. There is very little benefit to using 4:4:4 in the
+average case.
+
+However, there are some exceptions. The most notable is screen
+recordings. Things like text overlays, video game UI overlays,
+etc. have very fine, color-dependent detail that can be destroyed by
+chroma subsampling and result in an aliased look to the
+video. Therefore, it is recommended to use 4:4:4 subsampling when
+recording your screen, and 4:2:0 subsampling in most other cases.
+
+## Common formats
+
+| VS name     | FFmpeg name                                                                 | Meaning                                                                                               |
+| ----------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `GRAY8`     | `gray8`                                                                     | Brightness only, 8 bits, packed                                                                       |
+| `GRAY16`    | `gray16le`, `gray16be` (the suffix specifies the [endianness](#endianness)) | Brightness only, 16 bits                                                                              |
+| `RGB888`    | `rgb24`                                                                     | red, green, blue, 8 bits per component                                                                |
+| `YUV420P8`  | `yuv420p`                                                                   | luma, chroma blue, chroma red, 8 bits per component, planar, 4:2:0 [subsampling](#chroma-subsampling) |
+| `YUV422P8`  | `yuv422p`                                                                   | luma, chroma blue, chroma red, 8 bits per component, planar, 4:2:2 subsampling                        |
+| `YUV444P8`  | `yuv444p`                                                                   | luma, chroma blue, chroma red, 8 bits per component, planar, no subsampling                           |
+| `YUV420P10` | `yuv420p10le`, `yuv420p10le`                                                | luma, chroma blue, chroma red, 10 bits per component, planar, 4:2:0 subsampling                       |
+| `YUV422P10` | `yuv422p10le`, `yuv422p10le`                                                | luma, chroma blue, chroma red, 10 bits per component, planar, 4:2:2 subsampling                       |
+| `YUV444P10` | `yuv444p10le`, `yuv444p10le`                                                | luma, chroma blue, chroma red, 10 bits per component, planar, no subsampling                          |
+
+## References
+
+[^vlc-wiki-yuv]: [YUV - VideoLAN Wiki](https://wiki.videolan.org/YUV/#Packed_formats)

--- a/docs/colorimetry/intro.mdx
+++ b/docs/colorimetry/intro.mdx
@@ -1,0 +1,21 @@
+---
+title: Intro
+sidebar_position: 1
+---
+
+# Intro
+
+There are many aspects which determine how the color information
+for a video is stored and how it is rendered. As technology has improved,
+new standards developed, and with new techologies such as HDR,
+new standards continue to develop. However, the result is that
+it can be confusing to know which color settings to use for
+a given video.
+
+Some properties such as the color format must be set.
+However, properties such as color range, primaries, matrix coefficients,
+and transfer function are optional. It is always best practice to set these
+when you are encoding a video, because if they are not set, the player
+must make a guess as to what the correct settings are. If it guesses
+incorrectly, this can lead to the colors of the video being different
+from what was intended.

--- a/docs/colorimetry/matrix.mdx
+++ b/docs/colorimetry/matrix.mdx
@@ -1,0 +1,118 @@
+---
+title: Matrix Coefficients
+sidebar_position: 6
+---
+
+# Matrix Coefficients
+
+Matrix coefficients represent the multiplication matrix that is used when
+converting from YUV to RGB. As with primaries, the integer values are defined
+within universal specifications, and as such they will be the same across all
+encoding and playback tools.
+
+The following values are available:
+
+### 0: Identity
+
+Specifies that the identity matrix should be used, i.e. this data is already in an RGB-compatible colorspace.
+
+This matrix coefficient setting is used in the following standards:
+
+- GBR (often referred to as RGB)
+- YZX (often referred to as XYZ)
+- IEC 61966-2-1 sRGB
+- SMPTE ST 428-1 (2019)
+
+### 1: BT.709
+
+BT.709 is the standard used for modern high-definition video, and is a safe default assumption.
+
+This matrix coefficient setting is used in the following standards:
+
+- Rec. ITU-R BT.709-6
+- Rec. ITU-R BT.1361-0 conventional colour gamut system and extended colour
+  gamut system (historical)
+- IEC 61966-2-4 xvYCC709
+- SMPTE RP 177 (1993) Annex B
+
+### 2: Unspecified
+
+This value indicates that no color matrix is set for the video, and the player must decide which value to use.
+
+mpv will use the following heuristics in this case:
+
+```
+if width >= 1280 || height > 576 {
+    "BT.709"
+} else {
+    "SMPTE 170M"
+}
+```
+
+### 4: BT.470M
+
+BT.470M is a standard that was used in analog television systems in the United States.
+
+### 5: BT.470BG
+
+BT.470BG is a standard that was used for European (PAL) television systems and DVDs.
+
+This matrix coefficient setting is used in the following standards:
+
+- Rec. ITU-R BT.470-6 System B, G (historical)
+- Rec. ITU-R BT.601-7 625
+- Rec. ITU-R BT.1358-0 625 (historical)
+- Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM
+- IEC 61966-2-1 sYCC
+- IEC 61966-2-4 xvYCC601
+
+### 6: SMPTE 170M
+
+SMPTE 170M is a stanrard that was used for NTSC television systems and DVDs. Its matrix coefficients are equivalent to BT.470BG.
+
+This matrix coefficient setting is used in the following standards:
+
+- Rec. ITU-R BT.601-7 525
+- Rec. ITU-R BT.1358-1 525 or 625 (historical)
+- Rec. ITU-R BT.1700-0 NTSC
+- SMPTE ST 170 (2004)
+
+### 7: SMPTE 240M
+
+SMPTE 240M was an interim standard used during the early days of HDTV (1988-1998).
+
+### 8: YCgCo
+
+The YCoCg color model, also known as the YCgCo color model,
+is the color space formed from a simple transformation of
+an associated RGB color space into a luma value and
+two chroma values called chrominance green and chrominance orange.
+
+### 9: BT.2020 Non-Constant Luminance
+
+BT.2020 is a standard used for ultra-high-definition video, i.e. 4K and higher. It may be used with or without HDR, as HDR is defined by the transfer characteristics. If you do not know if you want non-constant or constant luminance, you probably want non-constant.
+
+This matrix coefficient setting is used in the following standards:
+
+- Rec. ITU-R BT.2020-2 (non-constant luminance)
+- Rec. ITU-R BT.2100-2 Y′CbCr
+
+### 10: BT.2020 Constant Luminance
+
+This is a variant of BT.2020 with constant luminance values, represented using the YcCbcCrc colorspace. You probably want the non-constant luminance variant instead, unless you know you want this one.
+
+### 11: SMPTE 2085
+
+SMPTE 2085 is a standard used with HDR signals in the XYZ colorspace. I've never actually seen it used in the wild.
+
+### 12: Chromaticity-Derived Non-Constant Luminance
+
+I'm not really sure when you would use this.
+
+### 13: Chromaticity-Derived Constant Luminance
+
+I'm not really sure when you would use this.
+
+### 14: ICtCp
+
+ICtCp is an alternative colorspace developed for use with HDR and wide gamut video, by Dolby because they love doing extra stuff like this. I've never actually seen it used in the wild.

--- a/docs/colorimetry/primaries.mdx
+++ b/docs/colorimetry/primaries.mdx
@@ -1,0 +1,136 @@
+---
+title: Color Primaries
+sidebar_position: 4
+---
+
+# Color Primaries
+
+This section details the first of three settings that are important
+for retaining accurate color when encoding videos, those settings
+being primaries, color matrix, and transfer characteristics.
+
+Color primaries are used to indicate the correct coordinates for the
+red, blue, and green colors. There are historical reasons for
+[why so many standards exist](https://xkcd.com/927/), and this guide
+will not go in depth into history lessons, but will explain what
+primaries are available and when to use each one.
+
+Note that for primaries, matrices, and transfer, you can view the values
+that are set on a video using a tool like [MediaInfo](https://mediaarea.net/en/MediaInfo).
+If there are no values set, the player will need to guess which values
+to use. A safe default assumption for most modern videos is BT.709,
+although this may vary depending on source and resolution for the video.
+It is strongly recommended to set the correct values when encoding.
+
+Each setting has at least one name and exactly one integer value
+representing it--most encoder softwares will accept one or more of the names,
+but some tooling such as Vapoursynth and MKVToolnix accepts the integer values
+instead. The integer values are defined within universal specifications,
+and as such they will be the same across all encoding and playback tools.
+
+### 1: BT.709
+
+BT.709 is the standard used for modern high-definition video, and is a safe default assumption.
+
+This color primary setting is used in the following standards:
+
+- Rec. ITU-R BT.709-6
+- Rec. ITU-R BT.1361-0 conventional colour gamut
+  system and extended colour gamut system (historical)
+- IEC 61966-2-1 sRGB or sYCC
+- IEC 61966-2-4
+- Society of Motion Picture and Television Engineers
+  (SMPTE) RP 177 (1993) Annex B
+
+### 2: Unspecified
+
+This value indicates that no color primary is set for the video, and the player must decide which value to use.
+
+mpv will use the following heuristics in this case:
+
+```
+if matrix == "BT.2020" {
+    "BT.2020"
+} else if matrix == "BT.709" {
+    "BT.709"
+} else if width >= 1280 || height > 576 {
+    "BT.709"
+} else if height == 576 {
+    "BT.470BG"
+} else if height == 480 || height == 488 {
+    "SMPTE 170M"
+} else {
+    "BT.709"
+}
+```
+
+### 4: BT.470M
+
+BT.470M is a standard that was used in analog television systems in the United States.
+
+This color primary setting is used in the following standards:
+
+- Rec. ITU-R BT.470-6 System M (historical)
+- United States National Television System Committee
+  1953 Recommendation for transmission standards for
+  color television
+- United States Federal Communications Commission
+  (2003) Title 47 Code of Federal Regulations 73.682 (a) (20)
+
+### 5: BT.470BG
+
+BT.470BG is a standard that was used for European (PAL) television systems and DVDs.
+
+This color primary setting is used in the following standards:
+
+- Rec. ITU-R BT.470-6 System B, G (historical)
+- Rec. ITU-R BT.601-7 625
+- Rec. ITU-R BT.1358-0 625 (historical)
+- Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM
+
+### 6: SMPTE 170M
+
+SMPTE 170M is a standard that was used for NTSC television systems and DVDs.
+
+- Rec. ITU-R BT.601-7 525
+- Rec. ITU-R BT.1358-1 525 or 625 (historical)
+- Rec. ITU-R BT.1700-0 NTSC
+- SMPTE ST 170 (2004)
+
+### 7: SMPTE 240M
+
+SMPTE 240M was an interim standard used during the early days of HDTV (1988-1998). Its primaries are equivalent to SMPTE 170M.
+
+### 8: Film
+
+This represents generic film using Illuminant C.
+
+### 9: BT.2020
+
+BT.2020 is a standard used for ultra-high-definition video, i.e. 4K and higher. It may be used with or without HDR, as HDR is defined by the transfer characteristics.
+
+This color primary setting is used in the following standards:
+
+- Rec. ITU-R BT.2020-2
+- Rec. ITU-R BT.2100-2
+
+### 10: SMPTE 428
+
+SMPTE 428 is used for D-Cinema Distribution Masters, aka DCDM.
+
+This color primary setting is used in the following standards:
+
+- SMPTE ST 428-1 (2019)
+- (CIE 1931 XYZ as in ISO 11664-1)
+
+### 11: DCI-P3
+
+DCI-P3 is a wide-gamut colorspace used alongside RGB. It is used internally by most HDR monitors on the market.
+
+### 12: Display-P3
+
+Display-P3 is a variant of DCI-P3 developed by Apple because they wanted to be different.
+
+### 22: EBU Tech 3213
+
+Nobody really knows what this is.

--- a/docs/colorimetry/range.mdx
+++ b/docs/colorimetry/range.mdx
@@ -1,0 +1,24 @@
+---
+title: Color Range
+sidebar_position: 3
+---
+
+# Color Range
+
+Range is a concept that describes the valid values for a pixel.
+Typically, RGB will use full range and YUV will use limited range.
+
+What does this mean?
+
+For 8-bit video, full range indicates that all values between 0-255
+may be used to represent a color value. On the other hand, limited range
+indicates that only values between 16-235, or 16-240 for chroma,
+are valid, and any values outside that range will be clamped to fit in
+that range. These expand to equivalent ranges for high bit depth videos.
+
+Why is limited range a thing that exists? Essentially, it's due to
+historical reasons, but it's a convention that we are stuck with today.
+Even though full range may provide slightly better color accuracy,
+it is far less meaningful for high bit depth content, and even
+HDR blu-rays use limited color range. Therefore, it is recommended to
+follow existing conventions.

--- a/docs/colorimetry/transfer.mdx
+++ b/docs/colorimetry/transfer.mdx
@@ -1,0 +1,134 @@
+---
+title: Transfer Characteristics
+sidebar_position: 5
+---
+
+# Transfer Characteristics
+
+Transfer characteristics, also known as transfer functions, represent the
+gamma function of a video--that is, how to convert from a gamma-compressed
+video to one that is in linear light. These are sometimes also called EOTF
+and OETF functions.
+
+As with primaries, the integer values are defined within universal specifications,
+and as such they will be the same across all encoding and playback tools.
+
+The following values are available:
+
+### 1: BT.1886
+
+BT.1886 is the standard used for most modern, SDR video, and is a safe default assumption.
+
+This transfer function is used in the following standards:
+
+- Rec. ITU-R BT.709-6
+- Rec. ITU-R BT.1361-0 conventional
+  colour gamut system (historical)
+
+### 2: Unspecified
+
+This value indicates that no transfer function is set for the video, and the player must decide which value to use.
+
+mpv will always assume BT.1886 in this case.
+
+### 4: BT.470M
+
+BT.470M is a standard that was used in analog television systems in the United States. This transfer represents a power function with a gamma of 2.2.
+
+This transfer function is used in the following standards:
+
+- Rec. ITU-R BT.470-6 System M
+  (historical)
+- United States National Television
+  System Committee 1953
+  Recommendation for transmission
+  standards for color television
+- United States Federal Communications
+  Commission (2003) Title 47 Code of
+  Federal Regulations 73.682 (a) (20)
+- Rec. ITU-R BT.1700-0 625 PAL and
+  625 SECAM
+
+### 5: BT.470BG
+
+BT.470BG is a standard that was used for European (PAL) television systems and DVDs. This transfer represents a power function with a gamma of 2.8.
+
+### 6: SMPTE 170M
+
+SMPTE 170M is a stanrard that was used for NTSC television systems and DVDs. Its transfer function is equivalent to BT.1886.
+
+This transfer function is used in the following standards:
+
+- Rec. ITU-R BT.601-7 525 or 625
+- Rec. ITU-R BT.1358-1 525 or 625
+  (historical)
+- Rec. ITU-R BT.1700-0 NTSC
+- SMPTE ST 170 (2004)
+
+### 7: SMPTE 240M
+
+SMPTE 240M was an interim standard used during the early days of HDTV (1988-1998).
+
+### 8: Linear
+
+This value indicates that the content is already in linear light.
+
+### 9: Logarithmic 100
+
+Indicates a logarithmic transfer function with a 100:1 range.
+
+### 10: Logarithmic 316
+
+Indicates a logarithmic transfer function with a (100 \* sqrt(10)):1 range.
+
+### 11: XVYCC
+
+Used in standard IEC 61966-2-4. I have no idea what this actually is.
+
+### 12: BT.1361E
+
+This was intended to be a standard for "future" television systems, but it never really came into use.
+
+### 13: sRGB
+
+Represents the sRGB colorspace.
+
+This transfer function is used in the following standards:
+
+- IEC 61966-2-1 sRGB (with
+  MatrixCoefficients equal to 0)
+- IEC 61966-2-1 sYCC (with
+  MatrixCoefficients equal to 5)
+
+### 14: BT.2020 10-bit
+
+Typically used with ultra-high-definition 10-bit SDR video. Its transfer function is equivalent to BT.1886.
+
+### 15: BT.2020 12-bit
+
+Typically used with ultra-high-definition 12-bit SDR video. Its transfer function is equivalent to BT.1886.
+
+### 16: PQ aka SMPTE 2084
+
+PQ is the most widely used transfer function for HDR content. It allows for a wider range of luminance to be represented than conventional transfer functions.
+
+This transfer function is used in the following standards:
+
+- SMPTE ST 2084 (2014) for 10-, 12-,
+  14- and 16-bit systems
+- Rec. ITU-R BT.2100-2 perceptual
+  quantization (PQ) system
+
+### 17: SMPTE 428
+
+SMPTE 428 is used for D-Cinema Distribution Masters, aka DCDM.
+
+### 18: HLG aka Hybrid Log-Gamma
+
+HLG is an alternative transfer function for HDR content used by some televisions.
+
+This transfer function is used in the following standards:
+
+- ARIB STD-B67 (2015)
+- Rec. ITU-R BT.2100-2 hybrid log-
+  gamma (HLG) system


### PR DESCRIPTION
This adds a section explaining video colorimetry, including color formats, range, matrix, transfer, and primaries, and details a list of available matrix, transfer, and primaries values.

This information is copied from my encoding guide, with some edits, as I attempt to consolidate info from my guide into this wiki.