### PR TITLE
Fix SVT Deep Dive 2 Rendering Incorrectly

### DIFF
--- a/blog/2023-12-30-svt-av1-deep-dive.mdx
+++ b/blog/2023-12-30-svt-av1-deep-dive.mdx
@@ -82,6 +82,8 @@ And more, like CDEF and restoration enabled, overlays and film-grain disabled...
       alt: 'Kaguya.h264 Efficiency Graph',
     },
   ]}
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 This could be too much information.
@@ -113,6 +115,8 @@ This could be too much information.
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Same again but without presets 9 to 13 for better clarity:
@@ -142,6 +146,8 @@ This could be too much information.
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Now for the "low quality" range (CRF28 -> 43):
@@ -171,6 +177,8 @@ This could be too much information.
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Same but without presets 9 to 13 for better clarity:
@@ -200,6 +208,8 @@ This could be too much information.
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - **Let's now see speed comparisons between all presets:**
@@ -236,6 +246,8 @@ As we can see, preset -1 is so abysmally slow it makes the graph unusable
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - **Now the speed graphs but with SSIMU2 on the y-axis instead of BPP: (logarithmic scale)**
@@ -265,6 +277,8 @@ As we can see, preset -1 is so abysmally slow it makes the graph unusable
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Here are speeds graphs for preset 1 to 6 with a linear scale:
@@ -294,6 +308,8 @@ As we can see, preset -1 is so abysmally slow it makes the graph unusable
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 One interpretation we can have is that **presets 2 to 4** have actually pretty close scores (pretty much the same at HQ, 2 points at max in the low quality range) but **preset 2** is **2x slower than preset 4**. The quality gap between **preset 2** and **preset 1** is even narrower but the speed penalty is also ~2x.
@@ -343,6 +359,8 @@ Except for the tunes, `--preset 4` is set due to its good balance of quality and
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Now let's focus on the "high quality" range (CRF8 -> 23):
@@ -372,6 +390,8 @@ Except for the tunes, `--preset 4` is set due to its good balance of quality and
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - And the "low quality" range (CRF28 -> 43):
@@ -401,6 +421,8 @@ Except for the tunes, `--preset 4` is set due to its good balance of quality and
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - And here is the speed difference:
@@ -430,6 +452,8 @@ Except for the tunes, `--preset 4` is set due to its good balance of quality and
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Graphs comparing the tunes individually between each others will be made available soon.
@@ -478,6 +502,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -507,6 +533,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > __tiles__ here are both slightly harmful and slower.
@@ -540,6 +568,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -569,6 +599,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > Except for the Jigokuraku clip, __aq-mode 0__ is harmful in the eyes of SSIMU2, while being slower at low CRF levels, and sometimes a match or faster at high CRF levels.
@@ -602,6 +634,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -631,6 +665,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > __aq-mode 1__ fares closer to __aq-mode 2__ than __aq-mode 0__ did, both in quality and speed, but is still overall inferior according to SSIMU2
@@ -664,6 +700,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -693,6 +731,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > According to SSIMU2, disabling CDEF barely impact efficiency. But as its a pretty demanding tool, there's a slight speed benefit of having it disabled too. I advise you to take these results with a grain of salt until the image comparisons, because in anime particularly, CDEF *can* be beneficial for the line-art.
@@ -726,6 +766,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -755,6 +797,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > __Dynamic GoP control__ yields bit-perfect results in all clips except for Blue Lock and Jigokuraku. There is no speed benefit to disabling it except in clips where it is in use. Let's not jump to conclusions too easily, the image comparisons will tell if it's "safe" to keep the setting disabled at all times or not.
@@ -788,6 +832,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -817,6 +863,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > __Deblocking loop filter__ can be slightly beneficial in some scenarios. In reverse, it is never harmful, so it is recommended to keep it default.
@@ -850,6 +898,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -879,6 +929,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > __fast-decode 1__ is pretty harmful in the Fate clip and slightly harmful in the rest. There is a speed benefit of enabling it though.
@@ -912,6 +964,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -941,6 +995,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > Finally something interesting to analyse!
@@ -978,6 +1034,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1007,6 +1065,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 ### `--lookahead 60` vs default `--lookahead -1` (auto)
 
@@ -1037,6 +1097,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1066,6 +1128,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 ### `--lookahead 120` (max) vs default `--lookahead -1` (auto)
@@ -1097,6 +1161,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1126,6 +1192,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > __lookahead__ seems to behave strangely when set...
@@ -1163,6 +1231,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1192,6 +1262,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > __overlays__ do not seem to either improve efficiency or performance.
@@ -1225,6 +1297,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1254,6 +1328,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > Enabling __quantization matrices__ alone increase efficiency at "high quality" with no real speed impact.
@@ -1287,6 +1363,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1316,6 +1394,8 @@ Keep in mind that I have observed multiple times in the past that __tune 0__ kep
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > Setting __qm-min__ to __0__ on top of enabling __quantization matrices__ can be beneficial in some clips at no added compute time.
@@ -1351,6 +1431,8 @@ I will re-tests many QMs ranges in the future, but I doubt it changed much from 
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1380,6 +1462,8 @@ I will re-tests many QMs ranges in the future, but I doubt it changed much from 
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > Even though the efficiencies are very similar, nothing is bit-perfect here. So according to SSIMU2, the __loop restoration filter__ isn't necessarily useful. However, just like CDEF, it's a pretty demanding tool, so disabling it yields some performance improvements. Let's take these with a grain of salt until the image comparisons.
@@ -1417,6 +1501,8 @@ In all the clips, the results are bit-perfect and there is no notable performanc
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1446,6 +1532,8 @@ In all the clips, the results are bit-perfect and there is no notable performanc
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > Interestingly enough, __screen content tools__ seem to improve efficiency according to SSIMU2, at the cost of a huge performance regression. After the image comparisons are published, I will conduct additional testing on this.
@@ -1479,6 +1567,8 @@ In all the clips, the results are bit-perfect and there is no notable performanc
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 - Speed graphs:
@@ -1508,6 +1598,8 @@ In all the clips, the results are bit-perfect and there is no notable performanc
       },
     ]
   }
+  pixelsAbove={0}
+  pixelsBelow={24}
 />
 
 > Disabled __temporal filtering__ *can* sometimes improve efficiency slightly at "high quality", however it is very much clip dependent. It also improves performance slightly. The image comparisons will give another perspective to these results.

--- a/blog/2024-05-19-svt-av1-deep-dive2-v2-1-0.mdx
+++ b/blog/2024-05-19-svt-av1-deep-dive2-v2-1-0.mdx
@@ -13,7 +13,6 @@ hide_table_of_contents: false
 ---
 
 import { CarouselGenerator, TabbedCarouselGenerator } from '../src/utils/ImageCarousel.mdx';
-import { Flex } from "antd";
 
 # Introduction
 
@@ -74,478 +73,438 @@ And more, like CDEF and restoration enabled, overlays and film-grain disabled...
 
 - First of all, here are the full efficiency graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/full/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 This is all very cool, but visually bloated.
 
 - Now the same graphs but focusing on the "high quality" range (CRF6 -> 22):
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Same, but now focusing on the "low quality" range (CRF26 -> 46):
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - If we now focus on __presets 4__ and below, where it's more difficult to discern the differences between presets, we get this at "high quality":
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - And the following at "low quality":
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/mrto4/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 ### Speed
 
 - **Let's now see speed comparisons between all presets:**
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speed/SVT-1_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Once is not custom, __preset -1__ is so abysmally slow it makes the graph unusable.
 
 - Same, but without the placebo __preset -1__:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speednomr/SVT0_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Lastly, here is what it looks like with a logarithmic scale:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.1.0-only/allpresets/speedlog/SVT-1_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 ### Interpretation
 
@@ -574,184 +533,169 @@ So the question for today's testing is: have the SVT-AV1 devs redeemed themselve
 
 - **Let's start off with a battle of the placebos, with the efficiency at "high quality":**
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - And the efficiency at "low quality":
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT-1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Yes, this is a bit underwhelming, but you can't just improve the best an encoder has to offer with just tweaking right?
 
 - Now, let's compare their respective speeds:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT-1_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Let's be grateful it became ever so slightly faster, I guess.
 
@@ -759,184 +703,169 @@ Let's be grateful it became ever so slightly faster, I guess.
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT0_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT0_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Overall, efficiency wise, this new **preset 0** places itself in-between old **preset -1** and **0**
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT0_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Interestingly enough, its speed is much closer to the old **preset 0** than to the old **preset -1**. This means **preset 0** was genuinely improved over v2.0.0!
 
@@ -944,184 +873,169 @@ Interestingly enough, its speed is much closer to the old **preset 0** than to t
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT1_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 In efficiency, this new **preset 1** is often equal to old **preset 0**, else in-between old **preset 0 and 1**.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT1_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 We observe that the new preset is a bit closer to old **preset 1** speeds than it is to old **preset 0** speeds. Good news!
 
@@ -1129,184 +1043,169 @@ We observe that the new preset is a bit closer to old **preset 1** speeds than i
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT2_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT2_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Oh well, that's awkward.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT2_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Speed was left untouched too, meaning **preset 2** is unchanged in v2.1.0.
 
@@ -1314,184 +1213,169 @@ Speed was left untouched too, meaning **preset 2** is unchanged in v2.1.0.
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT3_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT3_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 The new **preset 3**'s efficiency is the same as the old one.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT3_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 However, the preset got slightly faster, so this is a speedup!
 
@@ -1499,184 +1383,169 @@ However, the preset got slightly faster, so this is a speedup!
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT4_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT4_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 We can observe that **preset 4** got slightly to moderately worse efficiency wise.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT4_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Fortunately, the consequence of that slight efficiency decrease is a big performance improvement!
 
@@ -1684,184 +1553,169 @@ Fortunately, the consequence of that slight efficiency decrease is a big perform
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT5_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT5_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 **Preset 5** seems to have gotten ever so slightly worse efficiency wise.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT5_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Yet it became slightly faster, this is overall a good trade-off.
 
@@ -1869,184 +1723,169 @@ Yet it became slightly faster, this is overall a good trade-off.
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT6_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT6_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 The new **preset 6** has a huge responsibility: being able to compensate in the absence of its **preset 7** sibling. It seems to performs in-between old **preset 6 and 7**, usually closer to old **7**.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT6_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 **Preset 6** is now ever so slightly slower to old **7**, this is an interesting trade-off, overall a win over old **7**.
 
@@ -2060,184 +1899,169 @@ Again, there is no preset 7. Actually, it's preset 6 that disappeared but I'm no
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT8_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT8_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 In efficiency, this new **preset 8** is sometimes equal or slightly worse to the old **8**, and sometimes equal or slightly worse than old **7**...
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT8_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Overall, the speed is pretty much unchanged from old **8**. It looks like a slight regression, that's pretty disappointing.
 
@@ -2245,184 +2069,169 @@ Overall, the speed is pretty much unchanged from old **8**. It looks like a slig
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT9_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT9_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 The new **preset 9** is the same as ever, ever so slightly better in some scenario but nothing groundbreaking.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT9_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Its speed remains the same, sometimes ever so slightly slower. Basically the preset is pretty much unchanged, which may as well be a relief, as the last usable preset of the encoder.
 
@@ -2430,184 +2239,169 @@ Its speed remains the same, sometimes ever so slightly slower. Basically the pre
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT10_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT10_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 **Preset 10** is slightly to moderately worse efficiency wise.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT10_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Its speed is mostly the same, sometimes ever so slightly faster. It's a wash, avoid this preset at all costs!
 
@@ -2615,184 +2409,169 @@ Its speed is mostly the same, sometimes ever so slightly faster. It's a wash, av
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT11_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT11_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 **Preset 11**'s efficiency is untouched.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT11_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 **Preset 11**'s speed is unchanged as well.
 
@@ -2800,184 +2579,169 @@ Its speed is mostly the same, sometimes ever so slightly faster. It's a wash, av
 
 - Efficiency graphs, high quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/hq/SVT13_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 - Efficiency graphs, low quality:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'SSIMU2',
-        component: <CarouselGenerator
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_blame!_ssimu2.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_bluelock_ssimu2.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_jigokuraku-001_ssimu2.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_sxfed1_ssimu2.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-      xpsnr: {
-        label: 'XPSNR',
-        component: <CarouselGenerator 
-          imageData={[
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_blame!_xpsnr.webp',
-              alt: 'Blame!.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_bluelock_xpsnr.webp',
-              alt: 'BlueLock.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_jigokuraku-001_xpsnr.webp',
-              alt: 'Jigokuraku.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_sxfed1_xpsnr.webp',
-              alt: 'SpyxFamily.mkv Efficiency Graph',
-            },
-            {
-              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
-              alt: 'TheGardenOfSinners.mkv Efficiency Graph',
-            },
-          ]}
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'SSIMU2',
+      component: <CarouselGenerator
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_blame!_ssimu2.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_bluelock_ssimu2.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_jigokuraku-001_ssimu2.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_sxfed1_ssimu2.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_THE_GARDEN_OF_SINNERS_9_ssimu2.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+    xpsnr: {
+      label: 'XPSNR',
+      component: <CarouselGenerator 
+        imageData={[
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_blame!_xpsnr.webp',
+            alt: 'Blame!.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_bluelock_xpsnr.webp',
+            alt: 'BlueLock.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_jigokuraku-001_xpsnr.webp',
+            alt: 'Jigokuraku.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_sxfed1_xpsnr.webp',
+            alt: 'SpyxFamily.mkv Efficiency Graph',
+          },
+          {
+            src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/lq/SVT13_THE_GARDEN_OF_SINNERS_9_xpsnr.webp',
+            alt: 'TheGardenOfSinners.mkv Efficiency Graph',
+          },
+        ]}
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 Just as **preset 6**, **preset 12** is now mapped to **13**, and unsurprisingly, its efficiency is equal to old **13**.
 
 - Speed graphs:
 
-<Flex
-  justify='space-between'
-  vertical={true}
->
-  <div style={{ height: '0px' }} />
-  <TabbedCarouselGenerator
-    tabMap={{
-      ssimu2: {
-        label: 'Speed',
-        component: <CarouselGenerator
-          imageData={
-            [
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_blame!_speed.webp',
-                alt: 'Blame!.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_bluelock_speed.webp',
-                alt: 'BlueLock.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_jigokuraku-001_speed.webp',
-                alt: 'Jigokuraku.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_sxfed1_speed.webp',
-                alt: 'SpyxFamily.mkv Speed Graph',
-              },
-              {
-                src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_THE_GARDEN_OF_SINNERS_9_speed.webp',
-                alt: 'TheGardenOfSinners.mkv Speed Graph',
-              },
-            ]
-          }
-        />
-      },
-    }}
-  />
-  <div style={{ height: '24px' }} />
-</Flex>
+<TabbedCarouselGenerator
+  tabMap={{
+    ssimu2: {
+      label: 'Speed',
+      component: <CarouselGenerator
+        imageData={
+          [
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_blame!_speed.webp',
+              alt: 'Blame!.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_bluelock_speed.webp',
+              alt: 'BlueLock.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_jigokuraku-001_speed.webp',
+              alt: 'Jigokuraku.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_sxfed1_speed.webp',
+              alt: 'SpyxFamily.mkv Speed Graph',
+            },
+            {
+              src: 'https://raw.githubusercontent.com/av1-community-contributors/images/main/svt-2.1.0-blogpost/2.0.0vs2.1.0/speed/SVT13_THE_GARDEN_OF_SINNERS_9_speed.webp',
+              alt: 'TheGardenOfSinners.mkv Speed Graph',
+            },
+          ]
+        }
+      />
+    },
+  }}
+  pixelsAbove={0}
+  pixelsBelow={24}
+/>
 
 The speeds seem to be in-between old 12 and 13, so potentially a slight speedup. Still, nothing to get excited at.
 

--- a/src/utils/ImageCarousel.mdx
+++ b/src/utils/ImageCarousel.mdx
@@ -1,59 +1,87 @@
 import { useColorMode } from '@docusaurus/theme-common'
 import { useState } from 'react';
-import { ConfigProvider, theme, Carousel, Image, Card } from 'antd';
+import { ConfigProvider, Flex, theme, Carousel, Image, Card } from 'antd';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 
-export const CarouselGenerator = ({imageData}) => {
+export const CarouselGenerator = ({ imageData, pixelsAbove, pixelsBelow }) => {
   // Thanks to Nathan Arritt: https://github.com/ant-design/ant-design/issues/12479#issuecomment-1071492637
   const Arrow = ({ currentSlide, direction, slideCount, ...carouselProps }) =>
-  direction === 'left' ? (
-    <LeftOutlined {...carouselProps} style={{ color: '#fff', fontSize: 24, width: 24, height: 24, zIndex: 1, left: 10 }} />
-  ) : (
-    <RightOutlined {...carouselProps} style={{ color: '#fff', fontSize: 24, width: 24, height: 24, zIndex: 1, right: 10 }} />
-  );
+    direction === 'left' ? (
+      <LeftOutlined {...carouselProps} style={{ color: '#fff', fontSize: 24, width: 24, height: 24, zIndex: 1, left: 10 }} />
+    ) : (
+      <RightOutlined {...carouselProps} style={{ color: '#fff', fontSize: 24, width: 24, height: 24, zIndex: 1, right: 10 }} />
+    );
 
-  return(
-    <Carousel
-      // draggable // Image Preview Button prematurely triggers
-      arrows
-      prevArrow={<Arrow direction="left" />}
-      nextArrow={<Arrow direction="right" />}
+  if (!pixelsAbove || pixelsAbove < 0) {
+    pixelsAbove = 0;
+  }
+  if (!pixelsBelow || pixelsBelow < 0) {
+    pixelsBelow = 0;
+  }
+
+  return (
+    <Flex
+      justify='space-between'
+      vertical={true}
     >
-      {imageData.map(datum => {
-        return <Image
-          key={datum.src}
-          src={datum.src}
-        />;
-      })}
-    </Carousel>
+      <div style={{ height: `${pixelsAbove}px` }} />
+      <Carousel
+        // draggable // Image Preview Button prematurely triggers
+        arrows
+        prevArrow={<Arrow direction="left" />}
+        nextArrow={<Arrow direction="right" />}
+      >
+        {imageData.map(datum => {
+          return <Image
+            key={datum.src}
+            src={datum.src}
+          />;
+        })}
+      </Carousel>
+      <div style={{ height: `${pixelsBelow}px` }} />
+    </Flex>
   );
 };
 
-export const TabbedCarouselGenerator = ({ tabMap }) => {
+export const TabbedCarouselGenerator = ({ tabMap, pixelsAbove, pixelsBelow }) => {
   const [activeTabKey, setActiveTabKey] = useState(Object.keys(tabMap)[0]);
-  const {colorMode, setColorMode} = useColorMode();
+  const { colorMode, setColorMode } = useColorMode();
 
   const onTabChange = (key) => {
     setActiveTabKey(key);
   };
 
-  return(
+  if (!pixelsAbove || pixelsAbove < 0) {
+    pixelsAbove = 0;
+  }
+  if (!pixelsBelow || pixelsBelow < 0) {
+    pixelsBelow = 0;
+  }
+
+  return (
     <ConfigProvider
       theme={{
         algorithm: colorMode === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm
       }}
     >
-      <Card
-        tabList={
-          Object.entries(tabMap).map(([key, tab]) => {
-            return { key, label: tab.label };
-          })
-        }
-        activeTabKey={activeTabKey}
-        onTabChange={onTabChange}
+      <Flex
+        justify='space-between'
+        vertical={true}
       >
-        {tabMap[activeTabKey].component}
-      </Card>
+        <div style={{ height: `${pixelsAbove}px` }} />
+        <Card
+          tabList={
+            Object.entries(tabMap).map(([key, tab]) => {
+              return { key, label: tab.label };
+            })
+          }
+          activeTabKey={activeTabKey}
+          onTabChange={onTabChange}
+        >
+          {tabMap[activeTabKey].component}
+        </Card>
+        <div style={{ height: `${pixelsBelow}px` }} />
+      </Flex>
     </ConfigProvider>
   );
 };


### PR DESCRIPTION
Opening the SVT Deep Dive 2 blog post from a direct link or refreshing the page causes components to render incorrectly. Both the author and I have been unable to replicate these issues locally and cannot absolutely confirm any solution would resolve the issue and also maintain the spacing Flex component in use.

The best guess as to what is causing the issue may be related to how the MDX is importing dependencies both when the Flex component is imported and when the Carousel components are imported. Without any intimate knowledge of how MDX works, this is merely an assumption.

This refactor changes the blog such that Flex isn't being imported in the document, but rather in the utility function just like all the other components. Additionally, the original blog has been updated to match the style/spacing.

I highly recommend testing this change in a staging environment such that the live site is unaffected by any unexpected outcome.