### PR TITLE
fix: SVT Deep Dive 2 ConfigProvider causes rendering issues

### DIFF
--- a/src/utils/ImageCarousel.mdx
+++ b/src/utils/ImageCarousel.mdx
@@ -1,6 +1,5 @@
-import { useColorMode } from '@docusaurus/theme-common'
 import { useState } from 'react';
-import { ConfigProvider, Flex, theme, Carousel, Image, Card } from 'antd';
+import { Flex, Carousel, Image, Card } from 'antd';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 
 export const CarouselGenerator = ({ imageData, pixelsAbove, pixelsBelow }) => {
@@ -45,7 +44,6 @@ export const CarouselGenerator = ({ imageData, pixelsAbove, pixelsBelow }) => {
 
 export const TabbedCarouselGenerator = ({ tabMap, pixelsAbove, pixelsBelow }) => {
   const [activeTabKey, setActiveTabKey] = useState(Object.keys(tabMap)[0]);
-  const { colorMode, setColorMode } = useColorMode();
 
   const onTabChange = (key) => {
     setActiveTabKey(key);
@@ -59,29 +57,23 @@ export const TabbedCarouselGenerator = ({ tabMap, pixelsAbove, pixelsBelow }) =>
   }
 
   return (
-    <ConfigProvider
-      theme={{
-        algorithm: colorMode === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm
-      }}
+    <Flex
+      justify='space-between'
+      vertical={true}
     >
-      <Flex
-        justify='space-between'
-        vertical={true}
+      <div style={{ height: `${pixelsAbove}px` }} />
+      <Card
+        tabList={
+          Object.entries(tabMap).map(([key, tab]) => {
+            return { key, label: tab.label };
+          })
+        }
+        activeTabKey={activeTabKey}
+        onTabChange={onTabChange}
       >
-        <div style={{ height: `${pixelsAbove}px` }} />
-        <Card
-          tabList={
-            Object.entries(tabMap).map(([key, tab]) => {
-              return { key, label: tab.label };
-            })
-          }
-          activeTabKey={activeTabKey}
-          onTabChange={onTabChange}
-        >
-          {tabMap[activeTabKey].component}
-        </Card>
-        <div style={{ height: `${pixelsBelow}px` }} />
-      </Flex>
-    </ConfigProvider>
+        {tabMap[activeTabKey].component}
+      </Card>
+      <div style={{ height: `${pixelsBelow}px` }} />
+    </Flex>
   );
 };


### PR DESCRIPTION
Unfortunately, the theory that MDX importing Ant Design directly in a blog document seeming was not the root cause of the rendering issue. As the first blog renders correctly with the new Flex component, the only 2 candidates for causing the issue is the ConfigProvider and Card components.

ConfigProvider was necessary in order to provide a theme for the components that matched the current theme of the website. Users with dark theme pages would see dark themed components.

Card is a simple and commonly used component that is used to view content. In this case, the content had 2 versions so a tabbed interface was used to switch between versions. If removing the ConfigProvider does not resolve the rendering issue then the only remaining issue would be with the Card component - either the tabbed interface type or just the component itself.

There is a deeper issue here where components are not rendering correctly in some environments and the lack of being able to replicate it is quite troublesome for developing with this unreliable dependency. This may require some additional investigation into the changes required by Docusaurus v3 (updated after AntDesign was added) and whether or not new or old configuration changes need to be made in order to alleviate these rendering issues.