### PR TITLE
Remove Soichiro's encoding guide link

### DIFF
--- a/docs/resources.mdx
+++ b/docs/resources.mdx
@@ -11,7 +11,6 @@ Encoding resources that you might find useful.
 - https://guide.encode.moe - Filtering and fansubbing.
 - https://lvsfunc.encode.moe/en/latest - lvsfunc documentation.
 - https://silentaperture.gitlab.io/mdbook-guide/introduction.html - SilentAperture's Advanced Encoding guide, mostly about filtering.
-- https://encoding.bluefalcon.cc/ - Soichiro's "Encoding in Depth".
 - https://x265.readthedocs.io/en/master - x265 technical documentation, made by MulticoreWare themselves.
 - http://www.chaneru.com/Roku/HLS/X264_Settings.htm - x264 settings.
 - https://kokomins.wordpress.com/2019/10/10/anime-encoding-guide-for-x265-and-why-to-never-use-flac - Anime encoding guide by Kokomins. Has some pretty good advices regarding psychovisual stuff and x265.


### PR DESCRIPTION
I've migrated the completed portions over here, and am going to be focusing my efforts on building up this wiki and deprecating my guide