### PR TITLE
Fix a typo in rav1ator-cli.mdx

### DIFF
--- a/docs/utilities/rav1ator-cli.mdx
+++ b/docs/utilities/rav1ator-cli.mdx
@@ -135,7 +135,7 @@ The content in this entry was written by pat-e, or `pate` on Discord. This tutor
     wsl.exe --install --no-distribution
     ```
     
-    ![](https://raw.githubusercontent.com/av1-community-contributors/images/main/02_wsl_rv-cli.avifg)  
+    ![](https://raw.githubusercontent.com/av1-community-contributors/images/main/02_wsl_rv-cli.avif)  
       
     If the "Host Process for Windows Services" asks for allowing changes, approve it (Press "Yes"):  
     ![](https://raw.githubusercontent.com/av1-community-contributors/images/main/03_wsl_rv-cli.avif)


### PR DESCRIPTION
Fix the 2nd image not being shown