### PR TITLE
Update FFV1 and VVC pages (vvc decoder is now in FFmpeg)

### DIFF
--- a/docs/encoders/VVenC.mdx
+++ b/docs/encoders/VVenC.mdx
@@ -36,9 +36,11 @@ VVenC is an open source command line application for encoding [H.266/VVC](../vid
 
         ### FFmpeg Integration
 
-        Although not officially supported, you can compile your own FFmpeg binary with `libvvenc` and `libvvdec`. A comprehensive tutorial can be found in the [official VVenC wiki](https://github.com/fraunhoferhhi/vvenc/wiki/FFmpeg-Integration) ([archive](https://web.archive.org/web/20230509115800/https://github.com/fraunhoferhhi/vvenc/wiki/FFmpeg-Integration)).
+        Since June 15th 2024, you can officially compile your own FFmpeg binary with `libvvenc`. If you use earlier FFmpeg revision you will need to apply a custom patch. A comprehensive tutorial can be found in the [official VVenC wiki](https://github.com/fraunhoferhhi/vvenc/wiki/FFmpeg-Integration) ([archive](https://web.archive.org/web/20230509115800/https://github.com/fraunhoferhhi/vvenc/wiki/FFmpeg-Integration)).
 
-        The official guide is rather verbose, as FFmpeg (at the time of writing, 19 Feb 2024) does not support vvenc/vvdec officially. Below is an easy build script which uses an FFmpeg fork called FFmpeg-VVC. It is maintained by Marten Martin Eesmaa, who also maintains the [VVCEasy](https://github.com/MartinEesmaa/VVCEasy) GitHub repo featuring guides and more general information about working with VVC.
+        VVC decoder has been [integrated into FFmpeg](https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/301ed950d1c3c500d0c2eee8472587dc5e691c04) in early 2024, FFmpeg 7.0 is the first release to support it. However if you still want to compile FFmpeg with vvdec decoder (it has somewhat better performance), you can refer to the [official VVenC wiki](https://github.com/fraunhoferhhi/vvdec/wiki/FFmpeg-Integration) ([archive](https://web.archive.org/web/20240809090834/https://github.com/fraunhoferhhi/vvdec/wiki/FFmpeg-Integration)).
+
+        There's also a FFmpeg fork called [FFmpeg-VVC](https://github.com/MartinEesmaa/FFmpeg-VVC). It is maintained by Marten Martin Eesmaa, who is the author of [VVCEasy](https://github.com/MartinEesmaa/VVCEasy) GitHub repo featuring guides and more general information about working with VVC. It *might* provide more straight forward build experience but it's becoming less necessary as the VVC codec is slowly being integrated into mainline FFmpeg (and that's a good thing).
 
         Please be aware the script below produces a build of FFmpeg licensed under *LGPL version 2.1 or later*. It is legal to distribute the resulting binary, given you do not interfere with the flags provided below.
 
@@ -89,9 +91,14 @@ vvencapp -i input.y4m --preset slow --qpa on --qp 20 -c yuv420_10 -o output.266
 ffmpeg -hide_banner -loglevel error -i input.mkv -pix_fmt yuv420p10le -strict -1 -f yuv4mpegpipe - | vvencapp -i - --y4m --preset medium --qpa on --qp 20 -c yuv420_10 -o output.266
 ```
 
-:::warning Limitations
-VVenC currently does not support input resolutions below 540p. In addition, VVenC usually produces bitstreams that don't decode correctly when using FFmpeg's recently implemented native ffvvc decoder (this is true as of the time of writing on 19 Feb 2024). For proper decoding, build FFmpeg with libvvdec.
+```bash title="FFmpeg preset fast + qp 32 muxing to mp4"
+ffmpeg -i input.mkv -c:v libvvenc -qp 32 -preset fast out.mp4
+```
+
+:::info
+FFmpeg vvenc plugin only supports yuv420p10le output pixel format which means resulting video will always have 10 bit color depth.
 :::
+
 :::info QPA
 VVenC by default operates with QP (Quantization Parameter), which is basically fixed quality. For "CRF-like" rate control, QPA is enabled by default
 QPA (provided by --qpa) enables perceptually motivated QP adaptation based on [XPSNR](../metrics/XPSNR.mdx). QPA modifies the QP value on the fly spatially and temporally as well as enabling temporal RDO.

--- a/docs/video/FFV1.mdx
+++ b/docs/video/FFV1.mdx
@@ -9,4 +9,54 @@ sidebar_position: 12
 This section is in need of contributions. If you believe you can help, please see our [Contribution Guide](../contribution-guide.mdx) to get started as a contributor!
 :::
 
-FFV1 is a lossless codec designed for archival use & preservation. it is intra-only, meaning it doesn't use any compression techniques that take more than one frame into account for prediction. It is part of the [FFmpeg](../utilities/ffmpeg.mdx) project.
+FFV1 ([rfc9043](https://datatracker.ietf.org/doc/html/rfc9043)) is a lossless intra-frame video codec designed for archival use & preservation. Created by Michael Niedermayer it is part of the [FFmpeg](../utilities/ffmpeg.mdx) project. The codec supports wide range of color spaces. It can work with YUV and RGB content also including alpha channel with color depths ranging from 8 to 16 bits (only up to 14 in case of RGB). It has good parallelization support and achieves very high compression ratios compared to other lossless video encoders such as [UT Video](../video/utvideo.mdx) albeit at the cost of being more resource hungry.
+
+## History
+
+In 2003 the codec was merged into FFmpeg however the bistream specification was frozen in 2006 (officially FFV1 version 0). Later in 2009 came version 1 covering more bideo bit depths.
+
+Version 2 never got its release, it existed only in experimental form.
+
+The 3rd bistream version was frozen in 2013 and it's still the latest as of 2024. It added multithreading support and frame integrity checking.
+
+There is a 4th version [coming](https://datatracker.ietf.org/doc/draft-ietf-cellar-ffv1-v4/) which might bring better support for color spaces, compression improvements and [maybe](https://mailarchive.ietf.org/arch/msg/cellar/gFydpu8BKAgzspvy6Mvbpsrg5yY/) proper inter-frame prediction.
+
+## Usage
+
+```bash title="Fast, heavily multithreaded"
+ffmpeg -i input.mkv -c:v ffv1 -slices 16 out.mkv
+```
+
+```bash title="Slow, highest compression"
+ffmpeg -i input.mkv -c:v ffv1 -g 60 -slices 4 -context 1 -coder 2 out.mkv
+```
+
+```bash title="Recommended for archival purposes, high compression, multithreaded"
+ffmpeg -i input.mkv -c:v ffv1 -g 1 -slices 16 -slicecrc 1 -context 1 -coder 2 out.mkv
+```
+
+### Options
+- `slices` - Slices divide frame into multiple parts that can be encoded and decoded in parallel. Can only be one of: [`4`, `6`, `9`, `12`, `16`, `24`, `30`] where `4` is the default.
+- `slicecrc` - Setting it to `1` will enable decoder to detect errors in the bitstream. Must be enabled for archival use. Can be eitner `0` or `1`.
+- `context` - Setting it to `1` will make encoder use larger context size which usually leads to better compression. Can be eitner `0` or `1`.
+- `coder` - Sets entropy coding method:
+  - `0` - Golomb-Rice (faster, default)
+  - `1` - Range Coder (used for higher bit depths and better compression)
+  - `2` - Range Coder with custom state transition table (almost the same as `1`)
+- `g` - Sets `GOP size`. Must be `1` for archival use. [see below](#intra-frame-only-catch)
+
+## intra-frame only catch
+
+Intra-frame only codecs do not use common *inter*-frame video coding techniques such as [motion compensation](#TODO), reusing parts of surrounding frames or adapting encoding context based on them. Every frame is independent from one another. Common Intra-frame only codecs may include Motion JPEG (Lossy), Motion JPEG 2000 (Both) or [UT Video](../video/utvideo.mdx) (Lossless).
+
+If you're careful reader you might have noticed that setting `GOP size` isn't a common characteristic amongst intra-frame only codecs.
+
+In fact FFV1 can be considered an intra-frame codec only if `GOP size` is set to `1`. When it's larger than that, its context model depends on other frames found within the `GOP` which contradicts the definition of intra-frame only codec. The main reason why it's strongly recommended to set `GOP size` to `1` for archival purposes is that if one frame gets somehow corrupted, we only lost one frame. If `GOP size` was big we could loose much larger part of the video.
+
+References:
+- [Wikipedia](https://en.wikipedia.org/wiki/FFV1)
+- [RFC9043](https://datatracker.ietf.org/doc/html/rfc9043)
+- [FFmpeg Docs](https://trac.ffmpeg.org/wiki/Encode/FFV1)
+- [This Thread](https://forum.shotcut.org/t/exporting-as-ffv1-change-form-to-support-lossless-parameters/41230/19?page=2)
+- [This Question](https://video.stackexchange.com/questions/24874/what-does-the-context-parameter-mean-when-using-ffv1-in-ffmpeg)
+

--- a/docs/video/VVC.mdx
+++ b/docs/video/VVC.mdx
@@ -10,3 +10,5 @@ This section is in need of contributions. If you believe you can help, please se
 :::
 
 H.266, or VVC (Versatile Video Coding), is a codec standardized in 2020 by the Joint Video Experts Team (JVET). It succeeds [H.265](../video/HEVC.mdx), and claims to be 40% more efficient. In practice, it is currently about as efficient as [AV1](../video/AV1.mdx) when using the [VVenC](../encoders/VVenC.mdx) encoder, although it is inherently a more complex format which means it will be more difficult to decode. It is encumbered by royalties.
+
+[FFmpeg](../utilities/ffmpeg.mdx) 7.0 released in April 2024 comes with native VVC decoder.


### PR DESCRIPTION
Hello,
I added a few updates about building and using FFmpeg with VVC, added an example of encoding using with vvenc via FFmpeg directly.
I also updated FFV1 page to contain more details about how to encode with it and some command examples.