### PR TITLE
TC: Avoid the term gamma, note relative vs absolute transfer, add sRGB vs BT.470M note.

### DIFF
--- a/docs/colorimetry/transfer.mdx
+++ b/docs/colorimetry/transfer.mdx
@@ -11,16 +11,23 @@ the Transfer Characteristics to determine how to convert from a compressed
 video to a video that is in linear light, as well as converitng a linear 
 light video to a compressed video. These functions are known as EOTF, OETF, or OOTF.
 
+Note that in some transfer functions like sRGB, you need to undo the OETF. The 
+specification defines how to encode sRGB, and how a display should decode it,
+but not how to convert it back to linear light. In cases like these, it is typical
+to simply undo the encoding with an inverse transfer function, instead of using the 
+function the display is to use.
+
 This luminance can often be refered to as gamma, however due to the term gamma also 
 being used to refer to a myriad of other things, it is better to avoid this term when
 possible.
 
 Integer values much like with primaries are often used to define universal consants in
 the transfer functions. Transfer functions can either be absolute functions which
-specify the peak and minumum luminance, or be realtive functions which specify 
+specify the peak and minumum luminance, or be relative functions which specify 
 how to display a pixel within a range between maximum and minimum intensity.
-These transfer functions typical have a nominal reference brightness, but this
-is more of a suggestion rather then a hard requirement. Commonly seen with sRGB.
+These transfer functions typically have a nominal reference brightness, but this
+can be more of a suggestion rather then a hard requirement in some cases. Commonly 
+seen with sRGB.
 
 The following values are available:
 

--- a/docs/colorimetry/transfer.mdx
+++ b/docs/colorimetry/transfer.mdx
@@ -5,13 +5,22 @@ sidebar_position: 5
 
 # Transfer Characteristics
 
-Transfer characteristics, also known as transfer functions, represent the
-gamma function of a video--that is, how to convert from a gamma-compressed
-video to one that is in linear light. These are sometimes also called EOTF
-and OETF functions.
+Transfer characteristics, also known as transfer functions, define the 
+shaping used to compress the luminance or "brightness" of a video, we use
+the Transfer Characteristics to determine how to convert from a compressed
+video to a video that is in linear light, as well as converitng a linear 
+light video to a compressed video. These functions are known as EOTF, OETF, or OOTF.
 
-As with primaries, the integer values are defined within universal specifications,
-and as such they will be the same across all encoding and playback tools.
+This luminance can often be refered to as gamma, however due to the term gamma also 
+being used to refer to a myriad of other things, it is better to avoid this term when
+possible.
+
+Integer values much like with primaries are often used to define universal consants in
+the transfer functions. Transfer functions can either be absolute functions which
+specify the peak and minumum luminance, or be realtive functions which specify 
+how to display a pixel within a range between maximum and minimum intensity.
+These transfer functions typical have a nominal reference brightness, but this
+is more of a suggestion rather then a hard requirement. Commonly seen with sRGB.
 
 The following values are available:
 
@@ -99,6 +108,10 @@ This transfer function is used in the following standards:
   MatrixCoefficients equal to 0)
 - IEC 61966-2-1 sYCC (with
   MatrixCoefficients equal to 5)
+
+Note: Content often specifies that it is encoded with sRGB but in reality, is encoded in a pure 2.2
+function. While close there is a discrepency which often shows in the form of shadows taking on the wrong
+luminance. Specifying the encoding as BT.470M can be used to work around this.
 
 ### 14: BT.2020 10-bit
 


### PR DESCRIPTION
Gamma is an overloaded term, we have alternative more specific terms available, so it's best to use them.

Some transfers use absolute nits, some use relative nits, Reference nit values aren't always adhered to, so it's better to notify that since the relative nature means that it may not always look proper. Needs spellchecked and fact checked.