### PR TITLE
Fix broken links in `/docs` to improve compatibility with future translations

### DIFF
--- a/docs/contribution-guide.mdx
+++ b/docs/contribution-guide.mdx
@@ -30,7 +30,7 @@ The content in this entry is incomplete & is in the process of being completed.
 If you've added a new page & you aren't sure what should go there (this isn't recommended while there are still so many empty pages to be filled), add the following message as your page entry:
 
 :::danger Help Wanted
-This section is in need of contributions. If you believe you can help, please see our [Contribution Guide](../docs/contribution-guide.mdx) to get started as a contributor!
+This section is in need of contributions. If you believe you can help, please see our [Contribution Guide](/docs/contribution-guide) to get started as a contributor!
 :::
 
 ### Connect With Us

--- a/docs/encoders/aom-av1-lavish.mdx
+++ b/docs/encoders/aom-av1-lavish.mdx
@@ -204,7 +204,7 @@ Where:
 
 ## Recommendations
 
-aomenc unfortunately lacks the ability to take advantage of multiple threads, so therefore a tool like [Av1an](/docs/utilities/av1an.mdx) will be needed for parallelization. The parameters shown will be biased towards Av1an and aom-av1-lavish usage, so if you plan on using standalone aomenc then adjust as needed.
+aomenc unfortunately lacks the ability to take advantage of multiple threads, so therefore a tool like [Av1an](/docs/utilities/av1an) will be needed for parallelization. The parameters shown will be biased towards Av1an and aom-av1-lavish usage, so if you plan on using standalone aomenc then adjust as needed.
 
 Here are some recommended parameters:
 

--- a/docs/encoders/aomenc.mdx
+++ b/docs/encoders/aomenc.mdx
@@ -140,7 +140,7 @@ Where:
 
 ## Recommendations
 
-aomenc is largely lacking in its ability to take advantage of multiple threads, so a tool like [Av1an](/docs/utilities/av1an.mdx) should be utilized for effective parallelization. The parameters shown will be biased towards Av1an and [aom-av1-lavish](./aom-av1-lavish.mdx) usage, so if you plan on using standalone aomenc please adjust as needed.
+aomenc is largely lacking in its ability to take advantage of multiple threads, so a tool like [Av1an](/docs/utilities/av1an) should be utilized for effective parallelization. The parameters shown will be biased towards Av1an and [aom-av1-lavish](./aom-av1-lavish.mdx) usage, so if you plan on using standalone aomenc please adjust as needed.
 
 Here are some recommended parameters:
 

--- a/docs/video/utvideo.mdx
+++ b/docs/video/utvideo.mdx
@@ -6,7 +6,7 @@ sidebar_position: 13
 # UT Video Codec Suite
 
 :::danger Help Wanted
-This section is in need of contributions. If you believe you can help, please see our [Contribution Guide](/docs/contribution-guide.mdx) to get started as a contributor!
+This section is in need of contributions. If you believe you can help, please see our [Contribution Guide](/docs/contribution-guide) to get started as a contributor!
 :::
 
 UT Video Codec Suite is a fast, lossless video codec, developed by Takeshi Umezawa (梅澤 威志, Umezawa Takeshi) and released under the free GNU General Public License. The algorithm of UT video is based on the Huffman code.
@@ -15,7 +15,7 @@ UT Video was developed as an alternative to HuffYUV, in order to achieve better 
 
 It has both x86 and x64 builds. Due to its multithreading support, this codec is also capable of encoding HDTV material in real time. The codec requires support for the SSE2 instruction set because it is heavily used for speed optimizations.
 
-There are various predction modes, which can be used via [FFmpeg](/docs/utilities/ffmpeg.mdx):
+There are various predction modes, which can be used via [FFmpeg](/docs/utilities/ffmpeg):
 - no prediction employed
 - left neighbour prediction (continuous for the whole slice)
 - gradient prediction


### PR DESCRIPTION
This PR addresses several broken links in the `/docs` directory by standardizing the use of relative paths and removing `.mdx` extensions where necessary. These changes ensure that links are correctly resolved in all language versions of the site, improving the overall stability and maintainability of the documentation, particularly for future translation efforts.