### PR TITLE
Update dependancies for rvcli

### DIFF
--- a/docs/utilities/rav1ator-cli.mdx
+++ b/docs/utilities/rav1ator-cli.mdx
@@ -15,13 +15,13 @@ rAV1ator CLI was maintained by Gianni Rosato at https://github.com/gianni-rosato
 
 ```bash
 ~ > rav1ator-cli -h
-rAV1ator: CLI Edition_ v0.2.0
+rAV1ator: CLI Edition_ v0.2.4
 
 Usage:
 	rav1ator-cli [input] [output] [--offline]
 
 Dependencies (Arch): 
-	rust ffmpeg python mkvtoolnix-cli vapoursynth gum numactl l-smash vapoursynth-plugin-lsmashsource av1an ffms2
+	rust ffmpeg python mkvtoolnix-cli vapoursynth gum numactl vapoursynth-plugin-bestsource-git av1an ffms2
 
 Options: (Currently, only one option is useful at a time)
 	-h, --help			Print this help section
@@ -82,7 +82,7 @@ cd yay && makepkg -si
 
 2. Next, you'll want to install all of rav1ator-cli's dependencies. You can do that by running:
 ```bash
-yay -Syu openssl ffmpeg python mkvtoolnix-cli vapoursynth gum numactl l-smash vapoursynth-plugin-lsmashsource av1an ffms2
+yay -Syu openssl ffmpeg python mkvtoolnix-cli vapoursynth gum numactl vapoursynth-plugin-bestsource-git av1an ffms2
 ```
 
 3. Install rav1ator-cli:


### PR DESCRIPTION
As of rAV1ator-cli v0.4.0, the dependencies have changed, and the new list reflects this